### PR TITLE
Fix ARIA, TypeScript script tags, modal focus, unused imports, and content accuracy

### DIFF
--- a/src/content/projects/deck-rebuild.md
+++ b/src/content/projects/deck-rebuild.md
@@ -1,0 +1,24 @@
+---
+title: "Back Deck Rebuild"
+category: "home"
+status: "wip"
+description: "Full replacement of a 400 sq ft pressure-treated deck. New framing, composite decking, and rebuilt stairs. Planning integrated low-voltage lighting and a pergola extension."
+githubUrl: ""
+image: ""
+date: 2026-03-01
+featured: false
+tags: ["Carpentry", "Electrical", "Outdoor"]
+---
+
+## Overview
+
+The original deck was 15 years old with significant rot in the ledger board and outer joists. Full demo and rebuild — new PT framing, composite decking boards, and rebuilt stair stringers.
+
+## Phases
+
+1. **Demo & inspection** — complete
+2. **New framing** — complete
+3. **Decking installation** — in progress
+4. **Stairs & railings** — upcoming
+5. **Low-voltage lighting** — planning
+6. **Pergola extension** — planning

--- a/src/content/projects/deck-rebuild.md
+++ b/src/content/projects/deck-rebuild.md
@@ -3,7 +3,6 @@ title: "Back Deck Rebuild"
 category: "home"
 status: "wip"
 description: "Full replacement of a 400 sq ft pressure-treated deck. New framing, composite decking, and rebuilt stairs. Planning integrated low-voltage lighting and a pergola extension."
-githubUrl: ""
 image: ""
 date: 2026-03-01
 featured: false

--- a/src/content/projects/raised-bed-garden.md
+++ b/src/content/projects/raised-bed-garden.md
@@ -1,0 +1,26 @@
+---
+title: "Raised Bed Garden"
+category: "garden"
+status: "active"
+description: "Four 4x8 cedar raised beds growing tomatoes, peppers, herbs, and greens. Experimenting with companion planting, drip irrigation, and soil amendment cycles across seasons."
+githubUrl: ""
+image: ""
+date: 2025-04-01
+featured: false
+tags: ["Vegetables", "Irrigation", "Soil"]
+---
+
+## Overview
+
+Four cedar raised beds in a full-sun location. The primary goal is growing varieties suited to Virginia's hot, humid summers — heat-tolerant tomatoes, peppers, and herbs — while keeping the soil biology healthy between seasons.
+
+## Current Beds
+
+- **Bed 1:** Tomatoes (Brandywine, Cherokee Purple, Sun Gold)
+- **Bed 2:** Peppers (Carmen, Shishito, Jimmy Nardello)
+- **Bed 3:** Herbs (Basil, Oregano, Thyme, Rosemary)
+- **Bed 4:** Greens + beans (rotational)
+
+## Notes
+
+Drip irrigation on a timer. Compost top-dressed each spring. Experimenting with crimson clover as a winter cover crop.

--- a/src/content/projects/raised-bed-garden.md
+++ b/src/content/projects/raised-bed-garden.md
@@ -3,7 +3,6 @@ title: "Raised Bed Garden"
 category: "garden"
 status: "active"
 description: "Four 4x8 cedar raised beds growing tomatoes, peppers, herbs, and greens. Experimenting with companion planting, drip irrigation, and soil amendment cycles across seasons."
-githubUrl: ""
 image: ""
 date: 2025-04-01
 featured: false

--- a/src/content/projects/sybilsedge-site.md
+++ b/src/content/projects/sybilsedge-site.md
@@ -2,7 +2,7 @@
 title: "Sybilsedge.com"
 category: "tech"
 status: "active"
-description: "Personal digital identity site built with Astro 5, Tailwind CSS, and deployed on Cloudflare Pages. Blueprint-cyberpunk aesthetic with zero JS by default and Astro Islands for interactive components."
+description: "Personal digital identity site built with Astro 6, Tailwind CSS, and deployed on Cloudflare Workers. Blueprint-cyberpunk aesthetic with zero JS by default and Astro Islands for interactive components."
 githubUrl: "https://github.com/sybilsedge/sybilsedge"
 image: ""
 date: 2026-04-01
@@ -12,15 +12,15 @@ tags: ["Astro", "Tailwind", "Cloudflare", "TypeScript"]
 
 ## Overview
 
-This site is the project. Built in public on Cloudflare Pages using Astro 5 in SSR mode with the Cloudflare adapter. The design system is a blueprint-cyberpunk aesthetic — deep charcoal backgrounds, electric cyan and neon green accents, Orbitron headers, and a persistent CSS grid overlay that simulates a drafting board.
+This site is the project. Built in public on Cloudflare Workers using Astro 6 in SSR mode with the Cloudflare adapter. The design system is a blueprint-cyberpunk aesthetic — deep charcoal backgrounds, electric cyan and neon green accents, Orbitron headers, and a persistent CSS grid overlay that simulates a drafting board.
 
 ## Stack
 
-- **Framework:** Astro 5 (SSR, `@astrojs/cloudflare`)
+- **Framework:** Astro 6 (SSR, `@astrojs/cloudflare`)
 - **Styling:** Tailwind CSS v4
-- **Icons:** Lucide (inline SVG)
+- **Icons:** Inline SVG
 - **Data:** Astro Content Collections
-- **Deploy:** Cloudflare Pages
+- **Deploy:** Cloudflare Workers
 
 ## Status
 

--- a/src/content/projects/sybilsedge-site.md
+++ b/src/content/projects/sybilsedge-site.md
@@ -2,13 +2,26 @@
 title: "Sybilsedge.com"
 category: "tech"
 status: "active"
-description: "Personal digital identity site built with Astro 5, Tailwind CSS v4, and deployed on Cloudflare Pages. Blueprint-cyberpunk aesthetic with SSR, Content Collections, and zero-JS-by-default architecture."
+description: "Personal digital identity site built with Astro 5, Tailwind CSS, and deployed on Cloudflare Pages. Blueprint-cyberpunk aesthetic with zero JS by default and Astro Islands for interactive components."
 githubUrl: "https://github.com/sybilsedge/sybilsedge"
+image: ""
 date: 2026-04-01
 featured: true
-tags: ["astro", "cloudflare", "tailwind", "typescript"]
+tags: ["Astro", "Tailwind", "Cloudflare", "TypeScript"]
 ---
 
-# Sybilsedge.com
+## Overview
 
-This site — built in public, iterated continuously.
+This site is the project. Built in public on Cloudflare Pages using Astro 5 in SSR mode with the Cloudflare adapter. The design system is a blueprint-cyberpunk aesthetic — deep charcoal backgrounds, electric cyan and neon green accents, Orbitron headers, and a persistent CSS grid overlay that simulates a drafting board.
+
+## Stack
+
+- **Framework:** Astro 5 (SSR, `@astrojs/cloudflare`)
+- **Styling:** Tailwind CSS v4
+- **Icons:** Lucide (inline SVG)
+- **Data:** Astro Content Collections
+- **Deploy:** Cloudflare Pages
+
+## Status
+
+Active development. Building out content pillar pages iteratively.

--- a/src/content/recipes/slow-braised-short-ribs.md
+++ b/src/content/recipes/slow-braised-short-ribs.md
@@ -1,0 +1,44 @@
+---
+title: "Slow-Braised Short Ribs"
+category: "cooking"
+description: "Bone-in short ribs braised low and slow in red wine and beef stock. The kind of dish that makes the whole house smell right. Finished with a reduced glossy sauce."
+tags: ["Beef", "Braise", "Winter", "Dutch Oven"]
+prepTime: "30 min"
+cookTime: "3.5 hr"
+servings: 4
+date: 2025-12-15
+featured: false
+---
+
+## Ingredients
+
+- 4 bone-in short ribs (about 3 lbs / 1.4 kg)
+- Kosher salt and black pepper
+- 2 tbsp neutral oil
+- 1 large onion, roughly chopped
+- 3 carrots, roughly chopped
+- 4 celery stalks, roughly chopped
+- 6 garlic cloves, smashed
+- 2 tbsp tomato paste
+- 1 bottle (750ml) dry red wine (Cab Sauv or Merlot)
+- 2 cups beef stock
+- 4 sprigs fresh thyme
+- 2 bay leaves
+
+## Method
+
+1. **Season** — Pat ribs completely dry. Season aggressively with salt and pepper on all sides. Let sit at room temperature 30 minutes.
+2. **Sear** — Heat oil in a Dutch oven over high heat until smoking. Sear ribs in batches, 3 minutes per side, until deeply browned. Don’t crowd the pan. Set aside.
+3. **Sauté aromatics** — Reduce heat to medium. Cook onion, carrot, and celery in the rendered fat until softened, 8 minutes. Add garlic, cook 2 more minutes.
+4. **Tomato paste** — Push vegetables to the sides, add tomato paste to the centre. Cook, stirring, until it darkens and smells sweet, about 3 minutes.
+5. **Deglaze** — Add wine, scraping up all the fond. Bring to a boil and reduce by half, about 15 minutes.
+6. **Braise** — Add stock, thyme, and bay leaves. Nestle ribs in, bone-side up. Liquid should come about two-thirds up the ribs. Bring to a simmer.
+7. **Oven** — Cover and braise at 325°F/165°C for 3 to 3.5 hours, until meat is completely tender and pulling from the bone.
+8. **Rest & reduce** — Remove ribs carefully. Strain braising liquid, skim fat, and reduce over medium-high heat until glossy and lightly syrupy, 10–15 minutes.
+9. **Serve** — Plate ribs over mashed potatoes or polenta. Spoon sauce generously over the top.
+
+## Notes
+
+- The sear is non-negotiable. Colour equals flavour in the final sauce.
+- Can be made 2 days ahead — flavour improves significantly overnight in the fridge.
+- Skim the fat layer after refrigerating; it lifts off clean once cold.

--- a/src/content/recipes/sourdough-country-loaf.md
+++ b/src/content/recipes/sourdough-country-loaf.md
@@ -1,15 +1,45 @@
 ---
 title: "Sourdough Country Loaf"
 category: "baking"
-description: "A high-hydration open-crumb sourdough with a deep caramelized crust. Built on a 24-hour cold retard and a cast-iron bake."
-tags: ["sourdough", "bread", "cast-iron", "long-ferment"]
-prepTime: "30 min active, 24 hr ferment"
+description: "An open-crumb country loaf built on a 75% hydration dough with a long cold retard. Crisp crust, custardy interior, and the kind of tang that takes three days to develop properly."
+tags: ["Sourdough", "Bread", "Fermentation", "Long Process"]
+prepTime: "45 min active, 24–48 hr total"
 cookTime: "45 min"
 servings: 1
-date: 2026-03-10
+date: 2025-11-01
 featured: true
 ---
 
-# Sourdough Country Loaf
+## Ingredients
 
-Seed recipe — full instructions coming soon.
+- 450g bread flour (high protein, 12.5%+)
+- 50g whole wheat flour
+- 375g water (75% hydration), divided: 350g + 25g
+- 100g active starter (100% hydration, peak fed)
+- 10g fine sea salt
+
+## Method
+
+### Day 1 — Mix & Bulk Ferment
+
+1. **Autolyse** — Combine flours and 350g water. Mix until no dry flour remains. Rest 45 minutes covered.
+2. **Add starter** — Incorporate starter by pinching and folding. Rest 30 minutes.
+3. **Add salt** — Dissolve salt in remaining 25g water, work into dough. Rest 30 minutes.
+4. **Bulk ferment** — Over 4–5 hours at 76°F/24°C, perform 4 sets of stretch and folds at 30-minute intervals. Dough should increase ~60% in volume and feel airy.
+5. **Pre-shape** — Turn onto an unfloured surface. Shape into a loose round, bench rest 20 minutes uncovered.
+6. **Final shape** — Shape into a tight boule or batard. Place seam-side up in a well-floured banneton.
+
+### Day 2 — Proof & Bake
+
+7. **Cold retard** — Cover banneton with plastic and refrigerate 12–16 hours (or up to 48 for more flavour).
+8. **Preheat** — Place a Dutch oven in the oven and preheat to 500°F/260°C for at least 1 hour.
+9. **Score** — Turn cold dough onto parchment. Score decisively at 45° with a lame.
+10. **Bake covered** — Bake in Dutch oven lid-on for 20 minutes.
+11. **Bake uncovered** — Remove lid, reduce to 450°F/232°C, bake 20–25 minutes until deep mahogany.
+12. **Cool** — Rest on a wire rack for at least 1 hour before cutting. The crumb is still setting.
+
+## Notes
+
+- Starter timing is everything. Use it at peak — domed, not collapsed.
+- Cold retard is optional but develops significantly more flavour complexity.
+- Virginia summers may require shorter bulk times; watch volume, not the clock.

--- a/src/content/writing/noir-garden-journal.md
+++ b/src/content/writing/noir-garden-journal.md
@@ -2,12 +2,15 @@
 title: "Noir Garden Journal"
 genre: "Spy Thriller"
 status: "draft"
-synopsis: "A retired intelligence operative tends a greenhouse in rural Virginia while being slowly drawn back into a web of encrypted communications and old debts. Equal parts quiet dread and kinetic action."
-excerpt: "The orchids bloomed out of season. She noted it the way she noted everything — without surprise, without comment — filing the anomaly in the drawer of her mind she never opened twice."
-date: 2026-01-15
+synopsis: "A burned CIA case officer returns to her family's rural Virginia property to disappear. What she finds instead is a dead asset, a compromised network, and evidence that the operation she thought she'd buried is very much alive — and hunting her."
+excerpt: "The tomatoes were coming in wrong. Daria had grown them from seed, the same Brandywine stock her mother had saved for thirty years, but something in the soil had shifted. She crouched at the end of the row and pressed two fingers into the earth — still damp from last night's rain — and thought about the man she'd left in a ditch outside Bratislava. She hadn't thought about him in months. She thought about him now."
+coverImage: ""
+date: 2024-09-01
 featured: true
 ---
 
-# Noir Garden Journal
+## About the Project
 
-Work in progress. Chapter 08 currently in revision.
+Noir Garden Journal is a spy thriller set in rural Suffolk County, Virginia. The novel follows Daria Reyes, a former CIA case officer living under a maintenance legend on her late mother's small farm. When a dead asset turns up on a neighboring property, Daria is pulled back into a world she thought she'd escaped — one where the lines between handler and asset, loyalty and betrayal, have long since dissolved.
+
+The novel explores themes of institutional trust, the cost of compartmentalization, and what it means to rebuild an identity after the work that defined you is gone.

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,6 +1,5 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import SectionHeader from '../components/SectionHeader.astro';
 import TechCard from '../components/TechCard.astro';
 
 const pillars = [
@@ -40,7 +39,7 @@ const timeline = [
 ];
 
 const interests = [
-	'Astro 5', 'Cloudflare Workers', 'Spy Fiction', 'Sourdough', 'NFL', 'NHL',
+	'Astro', 'Cloudflare Workers', 'Spy Fiction', 'Sourdough', 'NFL', 'NHL',
 	'Anime', 'Hard Rock', 'Heavy Metal', 'Electronica', 'Home Projects', 'Gardening',
 ];
 
@@ -62,7 +61,7 @@ const pinSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" v
 				About Me
 			</h1>
 			<div class="mt-4 flex items-center gap-2 text-cyan-300/60">
-				<span set:html={pinSvg} />
+				<span set:html={pinSvg} aria-hidden="true" />
 				<span class="font-tech text-[11px] uppercase tracking-[0.16em]">Suffolk, Virginia, US</span>
 			</div>
 			<p class="mt-5 max-w-3xl text-base leading-relaxed text-slate-300/90">

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,35 +1,32 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import { Cpu, Hammer, Utensils, PenLine, Zap, MapPin } from 'lucide-react';
+import SectionHeader from '../components/SectionHeader.astro';
+import TechCard from '../components/TechCard.astro';
 
 const pillars = [
 	{
-		icon: PenLine,
+		iconSvg: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>`,
 		label: 'Writing',
-		description:
-			'Spy thrillers with technical depth. Characters shaped by tradecraft, loss, and the weight of knowing too much.',
-		accentClass: 'text-[#39ff14]',
+		description: 'Spy thrillers with technical depth. Characters shaped by tradecraft, loss, and the weight of knowing too much.',
+		tag: 'FICTION',
 	},
 	{
-		icon: Cpu,
+		iconSvg: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#00ffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><path d="M15 2v2"/><path d="M15 20v2"/><path d="M2 15h2"/><path d="M2 9h2"/><path d="M20 15h2"/><path d="M20 9h2"/><path d="M9 2v2"/><path d="M9 20v2"/></svg>`,
 		label: 'Tech & Cloud',
-		description:
-			'17+ years architecting enterprise systems. GCP-certified. Specialising in cloud, networking, security, and observability.',
-		accentClass: 'text-[#00ffff]',
+		description: '17+ years architecting enterprise systems. GCP-certified. Specialising in cloud, networking, security, and observability.',
+		tag: 'ARCHITECTURE',
 	},
 	{
-		icon: Hammer,
+		iconSvg: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 12-8.5 8.5c-.83.83-2.17.83-3 0 0 0 0 0 0 0a2.12 2.12 0 0 1 0-3L12 9"/><path d="M17.64 15 22 10.64"/><path d="m20.91 11.7-1.25-1.25c-.6-.6-.93-1.4-.93-2.25v-.86L16.01 4.6a5.56 5.56 0 0 0-3.94-1.64H9l.92.82A6.18 6.18 0 0 1 12 8.4v1.56l2 2h2.47l2.26 1.91"/></svg>`,
 		label: 'Maker & Home',
-		description:
-			'Home improvement projects, electronics tinkering, gardening, and the satisfaction of building things with your hands.',
-		accentClass: 'text-[#39ff14]',
+		description: 'Home improvement projects, electronics tinkering, gardening, and the satisfaction of building things with your hands.',
+		tag: 'MAKER',
 	},
 	{
-		icon: Utensils,
+		iconSvg: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#00ffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2"/><path d="M7 2v20"/><path d="M21 15V2a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3Zm0 0v7"/></svg>`,
 		label: 'Kitchen',
-		description:
-			'Sourdough. Slow braises. Fermentation experiments. Cooking as engineering — precise, iterative, occasionally explosive.',
-		accentClass: 'text-[#00ffff]',
+		description: 'Sourdough. Slow braises. Fermentation experiments. Cooking as engineering — precise, iterative, occasionally explosive.',
+		tag: 'CULINARY',
 	},
 ];
 
@@ -38,9 +35,18 @@ const timeline = [
 	{ year: '2024', event: 'Began writing Noir Garden Journal, a spy thriller set in rural Virginia.' },
 	{ year: '2022', event: 'Achieved Google Cloud Professional Cloud Architect certification.' },
 	{ year: '2015', event: 'Transitioned from network engineering into full-stack cloud architecture.' },
-	{ year: '2010', event: 'Completed Master\u2019s in Computer Science.' },
+	{ year: '2010', event: 'Completed Master’s in Computer Science.' },
 	{ year: '2008', event: 'First enterprise networking role — the beginning of 17+ years in IT infrastructure.' },
 ];
+
+const interests = [
+	'Astro 5', 'Cloudflare Workers', 'Spy Fiction', 'Sourdough', 'NFL', 'NHL',
+	'Anime', 'Hard Rock', 'Heavy Metal', 'Electronica', 'Home Projects', 'Gardening',
+];
+
+// Inline SVGs for section headings (replaces <Zap client:load />)
+const zapSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>`;
+const pinSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>`;
 ---
 
 <Layout
@@ -56,7 +62,7 @@ const timeline = [
 				About Me
 			</h1>
 			<div class="mt-4 flex items-center gap-2 text-cyan-300/60">
-				<MapPin size={14} client:load />
+				<span set:html={pinSvg} />
 				<span class="font-tech text-[11px] uppercase tracking-[0.16em]">Suffolk, Virginia, US</span>
 			</div>
 			<p class="mt-5 max-w-3xl text-base leading-relaxed text-slate-300/90">
@@ -72,62 +78,51 @@ const timeline = [
 
 		<!-- Content pillars -->
 		<section aria-labelledby="pillars-heading" class="mb-8">
-			<h2 id="pillars-heading" class="font-orbitron mb-4 text-sm uppercase tracking-[0.2em] text-cyan-300/70">
-				<Zap size={13} className="inline mr-2 text-[#39ff14]" client:load />
+			<h2 id="pillars-heading" class="font-orbitron mb-4 text-sm uppercase tracking-[0.2em] text-cyan-300/70 flex items-center gap-2">
+				<span set:html={zapSvg} />
 				Content Pillars
 			</h2>
 			<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
-				{
-					pillars.map(({ icon: Icon, label, description, accentClass }) => (
-						<article class="blueprint-border rounded-md bg-black/35 p-5 transition-shadow duration-200 hover:shadow-[0_0_20px_rgba(0,255,255,0.08)]">
-							<div class="mb-3 flex items-center gap-2">
-								<Icon size={18} className={accentClass} client:load />
-								<h3 class="font-orbitron text-sm uppercase tracking-[0.12em] text-cyan-100">{label}</h3>
-							</div>
-							<p class="text-sm leading-relaxed text-slate-300/80">{description}</p>
-						</article>
-					))
-				}
+				{pillars.map((pillar) => (
+					<TechCard
+						tag={pillar.tag}
+						title={pillar.label}
+						body={pillar.description}
+						iconSvg={pillar.iconSvg}
+					/>
+				))}
 			</div>
 		</section>
 
 		<!-- Timeline -->
 		<section aria-labelledby="timeline-heading" class="mb-8">
-			<h2 id="timeline-heading" class="font-orbitron mb-5 text-sm uppercase tracking-[0.2em] text-cyan-300/70">
-				<Zap size={13} className="inline mr-2 text-[#39ff14]" client:load />
+			<h2 id="timeline-heading" class="font-orbitron mb-5 text-sm uppercase tracking-[0.2em] text-cyan-300/70 flex items-center gap-2">
+				<span set:html={zapSvg} />
 				Timeline
 			</h2>
 			<div class="relative border-l border-cyan-300/20 pl-6 space-y-6">
-				{
-					timeline.map(({ year, event }) => (
-						<div class="relative">
-							<!-- Dot -->
-							<span class="absolute -left-[1.65rem] top-1 h-2.5 w-2.5 rounded-full border border-[#00ffff] bg-[#0a0a0a]" />
-							<p class="font-tech text-[11px] uppercase tracking-[0.18em] text-[#39ff14]">{year}</p>
-							<p class="mt-1 text-sm leading-relaxed text-slate-300/85">{event}</p>
-						</div>
-					))
-				}
+				{timeline.map(({ year, event }) => (
+					<div class="relative">
+						<span class="absolute -left-[1.65rem] top-1 h-2.5 w-2.5 rounded-full border border-[#00ffff] bg-[#0a0a0a]" />
+						<p class="font-tech text-[11px] uppercase tracking-[0.18em] text-[#39ff14]">{year}</p>
+						<p class="mt-1 text-sm leading-relaxed text-slate-300/85">{event}</p>
+					</div>
+				))}
 			</div>
 		</section>
 
 		<!-- Interests -->
 		<section aria-labelledby="interests-heading">
-			<h2 id="interests-heading" class="font-orbitron mb-4 text-sm uppercase tracking-[0.2em] text-cyan-300/70">
-				<Zap size={13} className="inline mr-2 text-[#39ff14]" client:load />
+			<h2 id="interests-heading" class="font-orbitron mb-4 text-sm uppercase tracking-[0.2em] text-cyan-300/70 flex items-center gap-2">
+				<span set:html={zapSvg} />
 				Currently Into
 			</h2>
 			<div class="flex flex-wrap gap-2">
-				{
-					[
-						'Astro 5', 'Cloudflare Workers', 'Spy Fiction', 'Sourdough', 'NFL', 'NHL',
-						'Anime', 'Hard Rock', 'Heavy Metal', 'Electronica', 'Home Projects', 'Gardening'
-					].map((tag) => (
-						<span class="rounded font-tech text-[11px] uppercase tracking-[0.14em] px-3 py-1 blueprint-border text-cyan-300/70 bg-black/30">
-							{tag}
-						</span>
-					))
-				}
+				{interests.map((tag) => (
+					<span class="rounded font-tech text-[11px] uppercase tracking-[0.14em] px-3 py-1 blueprint-border text-cyan-300/70 bg-black/30">
+						{tag}
+					</span>
+				))}
 			</div>
 		</section>
 

--- a/src/pages/kitchen.astro
+++ b/src/pages/kitchen.astro
@@ -37,15 +37,14 @@ const zapSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" v
 			</p>
 		</header>
 
-		<!-- Filter tabs -->
-		<div class="mb-6 flex flex-wrap gap-2" role="tablist" aria-label="Filter recipes by category">
+		<!-- Filter buttons -->
+		<div class="mb-6 flex flex-wrap gap-2" role="group" aria-label="Filter recipes by category">
 			{categories.map((cat) => (
 				<button
 					class="filter-btn rounded blueprint-border px-4 py-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-cyan-300/60 hover:text-cyan-100 transition-colors data-[active]:text-cyan-100 data-[active]:border-cyan-300/60 data-[active]:bg-cyan-300/5"
 					data-filter={cat}
 					data-active={cat === 'all' ? 'true' : undefined}
-					role="tab"
-					aria-selected={cat === 'all' ? 'true' : 'false'}
+					aria-pressed={cat === 'all' ? 'true' : 'false'}
 				>
 					{cat === 'all' ? 'All' : categoryConfig[cat].label}
 				</button>
@@ -118,7 +117,7 @@ const zapSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" v
 
 	</div>
 
-	<script>
+	<script lang="ts">
 		const buttons = document.querySelectorAll<HTMLButtonElement>('.filter-btn');
 		const cards = document.querySelectorAll<HTMLElement>('.recipe-card');
 
@@ -127,7 +126,7 @@ const zapSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" v
 				const isActive = btn.dataset.filter === cat;
 				if (isActive) { btn.setAttribute('data-active', 'true'); }
 				else { btn.removeAttribute('data-active'); }
-				btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+				btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
 			});
 			cards.forEach((card) => {
 				card.style.display = (cat === 'all' || card.dataset.category === cat) ? '' : 'none';

--- a/src/pages/kitchen.astro
+++ b/src/pages/kitchen.astro
@@ -1,0 +1,141 @@
+---
+import Layout from '../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+
+const allRecipes = await getCollection('recipes');
+const sorted = allRecipes.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+
+const categories = ['all', 'baking', 'cooking', 'preservation'] as const;
+
+const categoryConfig: Record<string, { label: string; color: string }> = {
+	baking:       { label: 'Baking',       color: 'text-amber-400/80 border-amber-400/30 bg-amber-400/5' },
+	cooking:      { label: 'Cooking',      color: 'text-[#39ff14]/80 border-[#39ff14]/30 bg-[#39ff14]/5' },
+	preservation: { label: 'Preservation', color: 'text-[#00ffff]/80 border-[#00ffff]/30 bg-[#00ffff]/5' },
+};
+
+// Inline SVGs
+const utensilsSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2"/><path d="M7 2v20"/><path d="M21 15V2a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3Zm0 0v7"/></svg>`;
+const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>`;
+const arrowSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>`;
+const zapSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>`;
+---
+
+<Layout
+	title="Kitchen | Sybilsedge"
+	description="Recipes — sourdough, slow braises, fermentation, and everything else that comes out of the kitchen."
+>
+	<div class="mx-auto w-full max-w-[1500px] px-4 py-6 md:px-8 md:py-10">
+
+		<!-- Page header -->
+		<header class="mb-8 rounded-md blueprint-border bg-black/35 p-5 md:p-8">
+			<p class="font-tech text-[11px] uppercase tracking-[0.22em] text-cyan-300/75">The Lab</p>
+			<h1 class="font-orbitron mt-2 text-2xl uppercase tracking-[0.12em] text-cyan-100 md:text-4xl">
+				Kitchen
+			</h1>
+			<p class="mt-4 max-w-2xl text-base leading-relaxed text-slate-300/85">
+				Recipes built like systems — precise, iterative, occasionally revised after catastrophic failure. Sourdough, slow braises, fermentation, and whatever else is on the worktop.
+			</p>
+		</header>
+
+		<!-- Filter tabs -->
+		<div class="mb-6 flex flex-wrap gap-2" role="tablist" aria-label="Filter recipes by category">
+			{categories.map((cat) => (
+				<button
+					class="filter-btn rounded blueprint-border px-4 py-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-cyan-300/60 hover:text-cyan-100 transition-colors data-[active]:text-cyan-100 data-[active]:border-cyan-300/60 data-[active]:bg-cyan-300/5"
+					data-filter={cat}
+					data-active={cat === 'all' ? 'true' : undefined}
+					role="tab"
+					aria-selected={cat === 'all' ? 'true' : 'false'}
+				>
+					{cat === 'all' ? 'All' : categoryConfig[cat].label}
+				</button>
+			))}
+		</div>
+
+		<!-- Recipe cards -->
+		{sorted.length === 0 ? (
+			<div class="blueprint-border rounded-md bg-black/35 p-12 text-center">
+				<div class="mb-4 flex justify-center opacity-30" set:html={utensilsSvg} />
+				<p class="font-orbitron text-sm uppercase tracking-[0.16em] text-cyan-300/50">No recipes yet</p>
+				<p class="mt-2 font-tech text-[11px] text-slate-400/60">Recipes will appear here once added to the collection.</p>
+			</div>
+		) : (
+			<div class="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3" id="recipes-grid">
+				{sorted.map((entry) => {
+					const cat = categoryConfig[entry.data.category];
+					return (
+						<article
+							class="recipe-card group blueprint-border rounded-md bg-black/35 p-6 flex flex-col gap-3 transition-shadow duration-200 hover:shadow-[0_0_24px_rgba(0,255,255,0.07)]"
+							data-category={entry.data.category}
+						>
+							<!-- Top row: icon + title -->
+							<div class="flex items-start gap-2.5">
+								<span set:html={utensilsSvg} class="shrink-0 opacity-70 mt-0.5" />
+								<h2 class="font-orbitron text-sm uppercase tracking-[0.1em] text-cyan-100 leading-tight">{entry.data.title}</h2>
+							</div>
+
+							<!-- Category badge + meta -->
+							<div class="flex flex-wrap items-center gap-2">
+								<span class={`rounded border font-tech text-[10px] uppercase tracking-[0.14em] px-2 py-0.5 ${cat.color}`}>{cat.label}</span>
+								{entry.data.prepTime && (
+									<span class="flex items-center gap-1 font-tech text-[10px] text-cyan-300/40">
+										<span set:html={clockSvg} />
+										{entry.data.prepTime}
+									</span>
+								)}
+								{entry.data.servings && (
+									<span class="font-tech text-[10px] text-cyan-300/35">Serves {entry.data.servings}</span>
+								)}
+							</div>
+
+							<!-- Description -->
+							<p class="text-sm leading-relaxed text-slate-300/80 flex-1">{entry.data.description}</p>
+
+							<!-- Tags -->
+							{entry.data.tags.length > 0 && (
+								<div class="flex flex-wrap gap-1.5">
+									{entry.data.tags.map((tag: string) => (
+										<span class="rounded font-tech text-[10px] uppercase tracking-[0.1em] px-2 py-0.5 bg-black/40 border border-cyan-300/10 text-cyan-300/45">{tag}</span>
+									))}
+								</div>
+							)}
+
+							<!-- View recipe link -->
+							<div class="mt-auto pt-1">
+								<a
+									href={`/kitchen/${entry.slug}`}
+									class="flex items-center gap-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-[#39ff14]/60 hover:text-[#39ff14] transition-colors w-fit"
+								>
+									View Recipe
+									<span set:html={arrowSvg} />
+								</a>
+							</div>
+						</article>
+					);
+				})}
+			</div>
+		)}
+
+	</div>
+
+	<script>
+		const buttons = document.querySelectorAll<HTMLButtonElement>('.filter-btn');
+		const cards = document.querySelectorAll<HTMLElement>('.recipe-card');
+
+		function setFilter(cat: string) {
+			buttons.forEach((btn) => {
+				const isActive = btn.dataset.filter === cat;
+				if (isActive) { btn.setAttribute('data-active', 'true'); }
+				else { btn.removeAttribute('data-active'); }
+				btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+			});
+			cards.forEach((card) => {
+				card.style.display = (cat === 'all' || card.dataset.category === cat) ? '' : 'none';
+			});
+		}
+
+		buttons.forEach((btn) => {
+			btn.addEventListener('click', () => setFilter(btn.dataset.filter ?? 'all'));
+		});
+	</script>
+</Layout>

--- a/src/pages/kitchen/[slug].astro
+++ b/src/pages/kitchen/[slug].astro
@@ -1,0 +1,183 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+
+export async function getStaticPaths() {
+	const recipes = await getCollection('recipes');
+	return recipes.map((entry) => ({
+		params: { slug: entry.slug },
+		props: { entry },
+	}));
+}
+
+const { entry } = Astro.props;
+const { Content } = await entry.render();
+
+const categoryConfig: Record<string, { label: string; color: string }> = {
+	baking:       { label: 'Baking',       color: 'text-amber-400/80 border-amber-400/30 bg-amber-400/5' },
+	cooking:      { label: 'Cooking',      color: 'text-[#39ff14]/80 border-[#39ff14]/30 bg-[#39ff14]/5' },
+	preservation: { label: 'Preservation', color: 'text-[#00ffff]/80 border-[#00ffff]/30 bg-[#00ffff]/5' },
+};
+
+const cat = categoryConfig[entry.data.category];
+
+const arrowSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg>`;
+const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>`;
+const utensilsSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2"/><path d="M7 2v20"/><path d="M21 15V2a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3Zm0 0v7"/></svg>`;
+---
+
+<Layout
+	title={`${entry.data.title} | Kitchen | Sybilsedge`}
+	description={entry.data.description}
+>
+	<div class="mx-auto w-full max-w-[960px] px-4 py-6 md:px-8 md:py-10">
+
+		<!-- Back link -->
+		<a
+			href="/kitchen"
+			class="mb-6 inline-flex items-center gap-2 font-tech text-[11px] uppercase tracking-[0.16em] text-cyan-300/50 hover:text-cyan-300 transition-colors"
+		>
+			<span set:html={arrowSvg} />
+			All Recipes
+		</a>
+
+		<!-- Page header -->
+		<header class="mb-8 rounded-md blueprint-border bg-black/35 p-6 md:p-8">
+			<div class="mb-3 flex flex-wrap items-center gap-2">
+				<span class={`rounded border font-tech text-[10px] uppercase tracking-[0.14em] px-2 py-0.5 ${cat.color}`}>{cat.label}</span>
+				<span class="font-tech text-[11px] text-cyan-300/35 ml-auto">{entry.data.date.getFullYear()}</span>
+			</div>
+			<h1 class="font-orbitron text-2xl uppercase tracking-[0.1em] text-cyan-100 md:text-3xl">
+				{entry.data.title}
+			</h1>
+			<p class="mt-4 text-base leading-relaxed text-slate-300/85">{entry.data.description}</p>
+
+			<!-- Meta row -->
+			<div class="mt-5 flex flex-wrap gap-4">
+				{entry.data.prepTime && (
+					<div class="flex items-center gap-1.5 font-tech text-[11px] text-cyan-300/50">
+						<span set:html={clockSvg} />
+						<span class="uppercase tracking-[0.14em]">Prep</span>
+						<span class="text-cyan-100/70">{entry.data.prepTime}</span>
+					</div>
+				)}
+				{entry.data.cookTime && (
+					<div class="flex items-center gap-1.5 font-tech text-[11px] text-cyan-300/50">
+						<span set:html={clockSvg} />
+						<span class="uppercase tracking-[0.14em]">Cook</span>
+						<span class="text-cyan-100/70">{entry.data.cookTime}</span>
+					</div>
+				)}
+				{entry.data.servings && (
+					<div class="flex items-center gap-1.5 font-tech text-[11px] text-cyan-300/50">
+						<span set:html={utensilsSvg} />
+						<span class="uppercase tracking-[0.14em]">Serves</span>
+						<span class="text-cyan-100/70">{entry.data.servings}</span>
+					</div>
+				)}
+			</div>
+
+			<!-- Tags -->
+			{entry.data.tags.length > 0 && (
+				<div class="mt-4 flex flex-wrap gap-1.5">
+					{entry.data.tags.map((tag: string) => (
+						<span class="rounded font-tech text-[10px] uppercase tracking-[0.1em] px-2 py-0.5 bg-black/40 border border-cyan-300/10 text-cyan-300/45">{tag}</span>
+					))}
+				</div>
+			)}
+		</header>
+
+		<!-- Recipe content -->
+		<div class="blueprint-border rounded-md bg-black/35 p-6 md:p-8 prose-recipe">
+			<Content />
+		</div>
+
+	</div>
+
+	<style>
+		.prose-recipe :global(h2) {
+			font-family: var(--font-orbitron);
+			font-size: 0.9rem;
+			text-transform: uppercase;
+			letter-spacing: 0.12em;
+			color: rgb(207 250 254 / 0.9);
+			margin-top: 1.75rem;
+			margin-bottom: 0.75rem;
+			padding-bottom: 0.4rem;
+			border-bottom: 1px solid rgb(0 255 255 / 0.1);
+		}
+		.prose-recipe :global(h3) {
+			font-family: var(--font-orbitron);
+			font-size: 0.8rem;
+			text-transform: uppercase;
+			letter-spacing: 0.1em;
+			color: rgb(57 255 20 / 0.7);
+			margin-top: 1.25rem;
+			margin-bottom: 0.5rem;
+		}
+		.prose-recipe :global(p) {
+			font-size: 0.925rem;
+			line-height: 1.75;
+			color: rgb(148 163 184 / 0.85);
+			margin-bottom: 1rem;
+		}
+		.prose-recipe :global(ul) {
+			margin: 0.5rem 0 1.25rem 0;
+			list-style: none;
+			padding: 0;
+		}
+		.prose-recipe :global(ul li) {
+			font-size: 0.925rem;
+			line-height: 1.7;
+			color: rgb(148 163 184 / 0.85);
+			margin-bottom: 0.4rem;
+			padding-left: 1.1rem;
+			position: relative;
+		}
+		.prose-recipe :global(ul li::before) {
+			content: '▸';
+			position: absolute;
+			left: 0;
+			color: rgb(0 255 255 / 0.35);
+			font-size: 0.7rem;
+			top: 0.25rem;
+		}
+		.prose-recipe :global(ol) {
+			margin: 0.5rem 0 1.25rem 0;
+			list-style: none;
+			padding: 0;
+			counter-reset: recipe-step;
+		}
+		.prose-recipe :global(ol li) {
+			font-size: 0.925rem;
+			line-height: 1.7;
+			color: rgb(148 163 184 / 0.85);
+			margin-bottom: 0.75rem;
+			padding-left: 2.25rem;
+			position: relative;
+			counter-increment: recipe-step;
+		}
+		.prose-recipe :global(ol li::before) {
+			content: counter(recipe-step);
+			position: absolute;
+			left: 0;
+			width: 1.5rem;
+			height: 1.5rem;
+			line-height: 1.5rem;
+			text-align: center;
+			font-family: var(--font-orbitron);
+			font-size: 0.6rem;
+			color: rgb(57 255 20 / 0.8);
+			border: 1px solid rgb(57 255 20 / 0.3);
+			border-radius: 3px;
+			top: 0.1rem;
+		}
+		.prose-recipe :global(strong) {
+			color: rgb(207 250 254 / 0.9);
+			font-weight: 600;
+		}
+		.prose-recipe :global(em) {
+			color: rgb(148 163 184 / 0.7);
+		}
+	</style>
+</Layout>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,0 +1,157 @@
+---
+import Layout from '../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+
+const allProjects = await getCollection('projects');
+const sorted = allProjects.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+
+const categories = ['all', 'tech', 'home', 'garden'] as const;
+
+const categoryConfig: Record<string, { label: string; color: string }> = {
+	tech:   { label: 'Tech',   color: 'text-[#00ffff]/80 border-[#00ffff]/30 bg-[#00ffff]/5' },
+	home:   { label: 'Home',   color: 'text-[#39ff14]/80 border-[#39ff14]/30 bg-[#39ff14]/5' },
+	garden: { label: 'Garden', color: 'text-amber-400/80 border-amber-400/30 bg-amber-400/5' },
+};
+
+const statusConfig: Record<string, { label: string; classes: string }> = {
+	active:   { label: 'ACTIVE',   classes: 'border-[#39ff14]/40 text-[#39ff14]/80 bg-[#39ff14]/5' },
+	wip:      { label: 'WIP',      classes: 'border-[#00ffff]/40 text-[#00ffff]/80 bg-[#00ffff]/5' },
+	complete: { label: 'COMPLETE', classes: 'border-white/25 text-white/60 bg-white/5' },
+	archived: { label: 'ARCHIVED', classes: 'border-slate-500/30 text-slate-500/60 bg-slate-500/5' },
+};
+
+// Inline SVGs
+const hammerSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 12-8.5 8.5c-.83.83-2.17.83-3 0 0 0 0 0 0 0a2.12 2.12 0 0 1 0-3L12 9"/><path d="M17.64 15 22 10.64"/><path d="m20.91 11.7-1.25-1.25c-.6-.6-.93-1.4-.93-2.25v-.86L16.01 4.6a5.56 5.56 0 0 0-3.94-1.64H9l.92.82A6.18 6.18 0 0 1 12 8.4v1.56l2 2h2.47l2.26 1.91"/></svg>`;
+const linkSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>`;
+const arrowSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>`;
+---
+
+<Layout
+	title="Projects | Sybilsedge"
+	description="Tech builds, home improvement projects, and garden experiments."
+>
+	<div class="mx-auto w-full max-w-[1500px] px-4 py-6 md:px-8 md:py-10">
+
+		<!-- Page header -->
+		<header class="mb-8 rounded-md blueprint-border bg-black/35 p-5 md:p-8">
+			<p class="font-tech text-[11px] uppercase tracking-[0.22em] text-cyan-300/75">Gallery</p>
+			<h1 class="font-orbitron mt-2 text-2xl uppercase tracking-[0.12em] text-cyan-100 md:text-4xl">
+				Projects
+			</h1>
+			<p class="mt-4 max-w-2xl text-base leading-relaxed text-slate-300/85">
+				Tech builds, home improvement, and garden experiments. Everything that gets built outside the day job.
+			</p>
+		</header>
+
+		<!-- Filter tabs -->
+		<div class="mb-6 flex flex-wrap gap-2" id="filter-tabs" role="tablist" aria-label="Filter projects by category">
+			{categories.map((cat) => (
+				<button
+					class="filter-btn rounded blueprint-border px-4 py-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-cyan-300/60 hover:text-cyan-100 transition-colors data-[active]:text-cyan-100 data-[active]:border-cyan-300/60 data-[active]:bg-cyan-300/5"
+					data-filter={cat}
+					data-active={cat === 'all' ? 'true' : undefined}
+					role="tab"
+					aria-selected={cat === 'all' ? 'true' : 'false'}
+				>
+					{cat === 'all' ? 'All' : categoryConfig[cat].label}
+				</button>
+			))}
+		</div>
+
+		<!-- Project cards -->
+		{sorted.length === 0 ? (
+			<div class="blueprint-border rounded-md bg-black/35 p-12 text-center">
+				<div class="mb-4 flex justify-center opacity-30" set:html={hammerSvg} />
+				<p class="font-orbitron text-sm uppercase tracking-[0.16em] text-cyan-300/50">No projects yet</p>
+				<p class="mt-2 font-tech text-[11px] text-slate-400/60">Project entries will appear here once added to the collection.</p>
+			</div>
+		) : (
+			<div class="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3" id="projects-grid">
+				{sorted.map((entry) => {
+					const { label: statusLabel, classes: statusClasses } = statusConfig[entry.data.status];
+					const cat = categoryConfig[entry.data.category];
+					return (
+						<article
+							class="project-card group blueprint-border rounded-md bg-black/35 p-6 flex flex-col gap-3 transition-shadow duration-200 hover:shadow-[0_0_24px_rgba(0,255,255,0.07)]"
+							data-category={entry.data.category}
+						>
+							<!-- Top row: icon + title + status -->
+							<div class="flex items-start justify-between gap-3">
+								<div class="flex items-center gap-2.5">
+									<span set:html={hammerSvg} class="shrink-0 opacity-70" />
+									<h2 class="font-orbitron text-sm uppercase tracking-[0.1em] text-cyan-100 leading-tight">{entry.data.title}</h2>
+								</div>
+								<span class={`shrink-0 rounded border font-tech text-[10px] uppercase tracking-[0.12em] px-2 py-0.5 ${statusClasses}`}>{statusLabel}</span>
+							</div>
+
+							<!-- Category + year -->
+							<div class="flex items-center gap-3">
+								<span class={`rounded border font-tech text-[10px] uppercase tracking-[0.14em] px-2 py-0.5 ${cat.color}`}>{cat.label}</span>
+								<span class="font-tech text-[11px] text-cyan-300/35">{entry.data.date.getFullYear()}</span>
+							</div>
+
+							<!-- Description -->
+							<p class="text-sm leading-relaxed text-slate-300/80 flex-1">{entry.data.description}</p>
+
+							<!-- Tags -->
+							{entry.data.tags.length > 0 && (
+								<div class="flex flex-wrap gap-1.5">
+									{entry.data.tags.map((tag: string) => (
+										<span class="rounded font-tech text-[10px] uppercase tracking-[0.1em] px-2 py-0.5 bg-black/40 border border-cyan-300/10 text-cyan-300/45">{tag}</span>
+									))}
+								</div>
+							)}
+
+							<!-- Footer: GitHub link + detail link -->
+							<div class="mt-auto flex items-center justify-between pt-1">
+								{entry.data.githubUrl ? (
+									<a
+										href={entry.data.githubUrl}
+										target="_blank"
+										rel="noopener noreferrer"
+										class="flex items-center gap-1.5 font-tech text-[11px] uppercase tracking-[0.14em] text-cyan-300/50 hover:text-cyan-300 transition-colors"
+										aria-label={`View ${entry.data.title} on GitHub`}
+									>
+										<span set:html={linkSvg} />
+										GitHub
+									</a>
+								) : <span />}
+								<a
+									href={`/projects/${entry.slug}`}
+									class="flex items-center gap-1.5 font-tech text-[11px] uppercase tracking-[0.14em] text-[#39ff14]/60 hover:text-[#39ff14] transition-colors"
+								>
+									Details
+									<span set:html={arrowSvg} />
+								</a>
+							</div>
+						</article>
+					);
+				})}
+			</div>
+		)}
+
+	</div>
+
+	<script>
+		const buttons = document.querySelectorAll<HTMLButtonElement>('.filter-btn');
+		const cards = document.querySelectorAll<HTMLElement>('.project-card');
+
+		function setFilter(cat: string) {
+			buttons.forEach((btn) => {
+				const isActive = btn.dataset.filter === cat;
+				btn.dataset.active = isActive ? 'true' : '';
+				btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+				if (isActive) btn.removeAttribute('data-active');
+				if (isActive) btn.setAttribute('data-active', 'true');
+			});
+			cards.forEach((card) => {
+				const match = cat === 'all' || card.dataset.category === cat;
+				card.style.display = match ? '' : 'none';
+			});
+		}
+
+		buttons.forEach((btn) => {
+			btn.addEventListener('click', () => setFilter(btn.dataset.filter ?? 'all'));
+		});
+	</script>
+</Layout>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -43,15 +43,14 @@ const arrowSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13"
 			</p>
 		</header>
 
-		<!-- Filter tabs -->
-		<div class="mb-6 flex flex-wrap gap-2" id="filter-tabs" role="tablist" aria-label="Filter projects by category">
+		<!-- Filter buttons -->
+		<div class="mb-6 flex flex-wrap gap-2" id="filter-tabs" role="group" aria-label="Filter projects by category">
 			{categories.map((cat) => (
 				<button
 					class="filter-btn rounded blueprint-border px-4 py-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-cyan-300/60 hover:text-cyan-100 transition-colors data-[active]:text-cyan-100 data-[active]:border-cyan-300/60 data-[active]:bg-cyan-300/5"
 					data-filter={cat}
 					data-active={cat === 'all' ? 'true' : undefined}
-					role="tab"
-					aria-selected={cat === 'all' ? 'true' : 'false'}
+					aria-pressed={cat === 'all' ? 'true' : 'false'}
 				>
 					{cat === 'all' ? 'All' : categoryConfig[cat].label}
 				</button>
@@ -132,17 +131,19 @@ const arrowSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13"
 
 	</div>
 
-	<script>
+	<script lang="ts">
 		const buttons = document.querySelectorAll<HTMLButtonElement>('.filter-btn');
 		const cards = document.querySelectorAll<HTMLElement>('.project-card');
 
 		function setFilter(cat: string) {
 			buttons.forEach((btn) => {
 				const isActive = btn.dataset.filter === cat;
-				btn.dataset.active = isActive ? 'true' : '';
-				btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
-				if (isActive) btn.removeAttribute('data-active');
-				if (isActive) btn.setAttribute('data-active', 'true');
+				btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+				if (isActive) {
+					btn.setAttribute('data-active', 'true');
+				} else {
+					btn.removeAttribute('data-active');
+				}
 			});
 			cards.forEach((card) => {
 				const match = cat === 'all' || card.dataset.category === cat;

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -1,6 +1,6 @@
 ---
 import Layout from '../../layouts/Layout.astro';
-import { getCollection, getEntry } from 'astro:content';
+import { getCollection } from 'astro:content';
 
 export async function getStaticPaths() {
 	const projects = await getCollection('projects');

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -1,0 +1,143 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getCollection, getEntry } from 'astro:content';
+
+export async function getStaticPaths() {
+	const projects = await getCollection('projects');
+	return projects.map((entry) => ({
+		params: { slug: entry.slug },
+		props: { entry },
+	}));
+}
+
+const { entry } = Astro.props;
+const { Content } = await entry.render();
+
+const statusConfig: Record<string, { label: string; classes: string }> = {
+	active:   { label: 'ACTIVE',   classes: 'border-[#39ff14]/40 text-[#39ff14]/80 bg-[#39ff14]/5' },
+	wip:      { label: 'WIP',      classes: 'border-[#00ffff]/40 text-[#00ffff]/80 bg-[#00ffff]/5' },
+	complete: { label: 'COMPLETE', classes: 'border-white/25 text-white/60 bg-white/5' },
+	archived: { label: 'ARCHIVED', classes: 'border-slate-500/30 text-slate-500/60 bg-slate-500/5' },
+};
+
+const categoryConfig: Record<string, { label: string; color: string }> = {
+	tech:   { label: 'Tech',   color: 'text-[#00ffff]/80 border-[#00ffff]/30 bg-[#00ffff]/5' },
+	home:   { label: 'Home',   color: 'text-[#39ff14]/80 border-[#39ff14]/30 bg-[#39ff14]/5' },
+	garden: { label: 'Garden', color: 'text-amber-400/80 border-amber-400/30 bg-amber-400/5' },
+};
+
+const { label: statusLabel, classes: statusClasses } = statusConfig[entry.data.status];
+const cat = categoryConfig[entry.data.category];
+
+const linkSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>`;
+const arrowSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg>`;
+---
+
+<Layout
+	title={`${entry.data.title} | Projects | Sybilsedge`}
+	description={entry.data.description}
+>
+	<div class="mx-auto w-full max-w-[960px] px-4 py-6 md:px-8 md:py-10">
+
+		<!-- Back link -->
+		<a
+			href="/projects"
+			class="mb-6 inline-flex items-center gap-2 font-tech text-[11px] uppercase tracking-[0.16em] text-cyan-300/50 hover:text-cyan-300 transition-colors"
+		>
+			<span set:html={arrowSvg} />
+			All Projects
+		</a>
+
+		<!-- Page header -->
+		<header class="mb-8 rounded-md blueprint-border bg-black/35 p-6 md:p-8">
+			<div class="mb-3 flex flex-wrap items-center gap-2">
+				<span class={`rounded border font-tech text-[10px] uppercase tracking-[0.14em] px-2 py-0.5 ${cat.color}`}>{cat.label}</span>
+				<span class={`rounded border font-tech text-[10px] uppercase tracking-[0.12em] px-2 py-0.5 ${statusClasses}`}>{statusLabel}</span>
+				<span class="font-tech text-[11px] text-cyan-300/35 ml-auto">{entry.data.date.getFullYear()}</span>
+			</div>
+			<h1 class="font-orbitron text-2xl uppercase tracking-[0.1em] text-cyan-100 md:text-3xl">
+				{entry.data.title}
+			</h1>
+			<p class="mt-4 text-base leading-relaxed text-slate-300/85">{entry.data.description}</p>
+
+			<!-- Tags -->
+			{entry.data.tags.length > 0 && (
+				<div class="mt-4 flex flex-wrap gap-1.5">
+					{entry.data.tags.map((tag: string) => (
+						<span class="rounded font-tech text-[10px] uppercase tracking-[0.1em] px-2 py-0.5 bg-black/40 border border-cyan-300/10 text-cyan-300/45">{tag}</span>
+					))}
+				</div>
+			)}
+
+			<!-- GitHub link -->
+			{entry.data.githubUrl && (
+				<a
+					href={entry.data.githubUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="mt-5 inline-flex items-center gap-2 rounded blueprint-border px-4 py-2 font-tech text-[11px] uppercase tracking-[0.16em] text-cyan-300/70 hover:text-cyan-100 transition-colors"
+				>
+					<span set:html={linkSvg} />
+					View on GitHub
+				</a>
+			)}
+		</header>
+
+		<!-- Markdown content -->
+		<div class="blueprint-border rounded-md bg-black/35 p-6 md:p-8 prose-project">
+			<Content />
+		</div>
+
+	</div>
+
+	<style>
+		.prose-project :global(h2) {
+			font-family: var(--font-orbitron);
+			font-size: 0.9rem;
+			text-transform: uppercase;
+			letter-spacing: 0.12em;
+			color: rgb(207 250 254 / 0.9);
+			margin-top: 1.75rem;
+			margin-bottom: 0.75rem;
+			padding-bottom: 0.4rem;
+			border-bottom: 1px solid rgb(0 255 255 / 0.1);
+		}
+		.prose-project :global(h3) {
+			font-family: var(--font-orbitron);
+			font-size: 0.8rem;
+			text-transform: uppercase;
+			letter-spacing: 0.1em;
+			color: rgb(0 255 255 / 0.7);
+			margin-top: 1.25rem;
+			margin-bottom: 0.5rem;
+		}
+		.prose-project :global(p) {
+			font-size: 0.925rem;
+			line-height: 1.75;
+			color: rgb(148 163 184 / 0.85);
+			margin-bottom: 1rem;
+		}
+		.prose-project :global(ul), .prose-project :global(ol) {
+			margin: 0.75rem 0 1rem 1.25rem;
+		}
+		.prose-project :global(li) {
+			font-size: 0.925rem;
+			line-height: 1.7;
+			color: rgb(148 163 184 / 0.8);
+			margin-bottom: 0.35rem;
+		}
+		.prose-project :global(strong) {
+			color: rgb(207 250 254 / 0.9);
+			font-weight: 600;
+		}
+		.prose-project :global(code) {
+			font-family: var(--font-tech);
+			font-size: 0.8rem;
+			background: rgb(0 255 255 / 0.06);
+			border: 1px solid rgb(0 255 255 / 0.12);
+			border-radius: 3px;
+			padding: 0.1em 0.4em;
+			color: rgb(0 255 255 / 0.75);
+		}
+	</style>
+</Layout>

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -85,7 +85,7 @@ const briefcaseSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height=
 				onclick="window.print()"
 				class="mt-5 flex items-center gap-2 rounded blueprint-border px-4 py-2 font-tech text-[11px] uppercase tracking-[0.16em] text-cyan-300/80 hover:text-cyan-100 transition-colors print:hidden"
 			>
-				<span set:html={zapSvg} />
+				<span set:html={zapSvg} aria-hidden="true" />
 				Print / Save PDF
 			</button>
 		</header>

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -1,6 +1,5 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import { Cpu, Zap, Award, Briefcase, GraduationCap } from 'lucide-react';
 
 const skills = {
 	Cloud: ['Google Cloud Platform (GCP)', 'Cloudflare', 'AWS (working knowledge)', 'Terraform', 'Kubernetes'],
@@ -58,11 +57,18 @@ const certs = [
 	{ name: 'Professional Cloud Network Engineer', issuer: 'Google Cloud', year: '2021', highlight: false },
 	{ name: 'Associate Cloud Engineer', issuer: 'Google Cloud', year: '2020', highlight: false },
 ];
+
+// Inline SVGs replacing lucide-react dynamic refs
+const zapSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>`;
+const awardSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="6"/><path d="M15.477 12.89 17 22l-5-3-5 3 1.523-9.11"/></svg>`;
+const cpuSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#00ffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><path d="M15 2v2"/><path d="M15 20v2"/><path d="M2 15h2"/><path d="M2 9h2"/><path d="M20 15h2"/><path d="M20 9h2"/><path d="M9 2v2"/><path d="M9 20v2"/></svg>`;
+const capSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#00ffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0z"/><path d="M22 10v6"/><path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5"/></svg>`;
+const briefcaseSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#00ffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="14" x="2" y="7" rx="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/></svg>`;
 ---
 
 <Layout
 	title="Resume | Sybilsedge"
-	description="Senior Cloud Architect with 17+ years of experience in cloud, networking, security, and observability. GCP Certified. Master\u2019s in Computer Science."
+	description="Senior Cloud Architect with 17+ years of experience in cloud, networking, security, and observability. GCP Certified. Master’s in Computer Science."
 >
 	<div class="mx-auto w-full max-w-[1500px] px-4 py-6 md:px-8 md:py-10 print:px-0 print:py-0">
 
@@ -75,67 +81,62 @@ const certs = [
 			<p class="mt-3 font-tech text-[11px] uppercase tracking-[0.16em] text-cyan-300/60 print:text-gray-500">
 				Senior Cloud Architect &nbsp;&bull;&nbsp; 17+ Years Experience &nbsp;&bull;&nbsp; Suffolk, VA
 			</p>
-			<!-- Print button — hidden on print -->
 			<button
 				onclick="window.print()"
 				class="mt-5 flex items-center gap-2 rounded blueprint-border px-4 py-2 font-tech text-[11px] uppercase tracking-[0.16em] text-cyan-300/80 hover:text-cyan-100 transition-colors print:hidden"
 			>
-				<Zap size={12} className="text-[#39ff14]" client:load />
+				<span set:html={zapSvg} />
 				Print / Save PDF
 			</button>
 		</header>
 
 		<div class="grid grid-cols-1 gap-6 lg:grid-cols-[300px_1fr] print:grid-cols-[240px_1fr]">
 
-			<!-- LEFT COLUMN: Skills + Certs + Education -->
+			<!-- LEFT COLUMN: Certs + Skills + Education -->
 			<aside class="space-y-6">
 
 				<!-- Certifications -->
 				<section aria-labelledby="certs-heading" class="blueprint-border rounded-md bg-black/35 p-5 print:border print:border-gray-300 print:bg-white">
-					<h2 id="certs-heading" class="font-orbitron mb-4 text-xs uppercase tracking-[0.2em] text-cyan-300/70 print:text-gray-700">
-						<Award size={13} className="inline mr-2 text-[#39ff14]" client:load />
+					<h2 id="certs-heading" class="font-orbitron mb-4 text-xs uppercase tracking-[0.2em] text-cyan-300/70 flex items-center gap-2 print:text-gray-700">
+						<span set:html={awardSvg} />
 						Certifications
 					</h2>
 					<ul class="space-y-3" role="list">
-						{
-							certs.map(({ name, issuer, year, highlight }) => (
-								<li class={`rounded p-3 ${ highlight ? 'neon-border bg-[#39ff14]/5' : 'blueprint-border bg-black/20 print:border-gray-200' }`}>
-									<p class={`font-tech text-[11px] uppercase tracking-[0.14em] ${ highlight ? 'text-[#39ff14]' : 'text-cyan-300/70 print:text-gray-500' }`}>
-										{issuer} &middot; {year}
-									</p>
-									<p class="mt-1 text-sm text-slate-200/90 print:text-gray-800">{name}</p>
-								</li>
-							))
-						}
+						{certs.map(({ name, issuer, year, highlight }) => (
+							<li class={`rounded p-3 ${ highlight ? 'neon-border bg-[#39ff14]/5' : 'blueprint-border bg-black/20 print:border-gray-200' }`}>
+								<p class={`font-tech text-[11px] uppercase tracking-[0.14em] ${ highlight ? 'text-[#39ff14]' : 'text-cyan-300/70 print:text-gray-500' }`}>
+									{issuer} &middot; {year}
+								</p>
+								<p class="mt-1 text-sm text-slate-200/90 print:text-gray-800">{name}</p>
+							</li>
+						))}
 					</ul>
 				</section>
 
 				<!-- Skills -->
 				<section aria-labelledby="skills-heading" class="blueprint-border rounded-md bg-black/35 p-5 print:border print:border-gray-300 print:bg-white">
-					<h2 id="skills-heading" class="font-orbitron mb-4 text-xs uppercase tracking-[0.2em] text-cyan-300/70 print:text-gray-700">
-						<Cpu size={13} className="inline mr-2 text-[#00ffff]" client:load />
+					<h2 id="skills-heading" class="font-orbitron mb-4 text-xs uppercase tracking-[0.2em] text-cyan-300/70 flex items-center gap-2 print:text-gray-700">
+						<span set:html={cpuSvg} />
 						Skills
 					</h2>
 					<div class="space-y-4">
-						{
-							Object.entries(skills).map(([category, items]) => (
-								<div>
-									<p class="font-tech text-[10px] uppercase tracking-[0.2em] text-[#00ffff]/60 mb-2 print:text-gray-500">{category}</p>
-									<ul class="space-y-1" role="list">
-										{items.map((item) => (
-											<li class="font-tech text-[11px] text-slate-300/80 before:content-['▸_'] before:text-cyan-300/40 print:text-gray-700">{item}</li>
-										))}
-									</ul>
-								</div>
-							))
-						}
+						{Object.entries(skills).map(([category, items]) => (
+							<div>
+								<p class="font-tech text-[10px] uppercase tracking-[0.2em] text-[#00ffff]/60 mb-2 print:text-gray-500">{category}</p>
+								<ul class="space-y-1" role="list">
+									{items.map((item) => (
+										<li class="font-tech text-[11px] text-slate-300/80 before:content-['▸_'] before:text-cyan-300/40 print:text-gray-700">{item}</li>
+									))}
+								</ul>
+							</div>
+						))}
 					</div>
 				</section>
 
 				<!-- Education -->
 				<section aria-labelledby="edu-heading" class="blueprint-border rounded-md bg-black/35 p-5 print:border print:border-gray-300 print:bg-white">
-					<h2 id="edu-heading" class="font-orbitron mb-4 text-xs uppercase tracking-[0.2em] text-cyan-300/70 print:text-gray-700">
-						<GraduationCap size={13} className="inline mr-2 text-[#00ffff]" client:load />
+					<h2 id="edu-heading" class="font-orbitron mb-4 text-xs uppercase tracking-[0.2em] text-cyan-300/70 flex items-center gap-2 print:text-gray-700">
+						<span set:html={capSvg} />
 						Education
 					</h2>
 					<div>
@@ -148,52 +149,40 @@ const certs = [
 
 			<!-- RIGHT COLUMN: Experience -->
 			<section aria-labelledby="exp-heading">
-				<h2 id="exp-heading" class="font-orbitron mb-5 text-xs uppercase tracking-[0.2em] text-cyan-300/70 print:text-gray-700">
-					<Briefcase size={13} className="inline mr-2 text-[#00ffff]" client:load />
+				<h2 id="exp-heading" class="font-orbitron mb-5 text-xs uppercase tracking-[0.2em] text-cyan-300/70 flex items-center gap-2 print:text-gray-700">
+					<span set:html={briefcaseSvg} />
 					Experience
 				</h2>
 				<div class="space-y-5">
-					{
-						experience.map(({ title, org, period, bullets }) => (
-							<article class="blueprint-border rounded-md bg-black/35 p-5 print:border print:border-gray-300 print:bg-white print:break-inside-avoid">
-								<div class="mb-3 flex flex-wrap items-baseline justify-between gap-2">
-									<h3 class="font-orbitron text-sm uppercase tracking-[0.1em] text-cyan-100 print:text-black">{title}</h3>
-									<span class="font-tech text-[11px] uppercase tracking-[0.14em] text-cyan-300/50 print:text-gray-400">{period}</span>
-								</div>
-								<p class="font-tech text-[10px] uppercase tracking-[0.18em] text-[#39ff14]/70 mb-3 print:text-gray-500">{org}</p>
-								<ul class="space-y-2" role="list">
-									{bullets.map((b) => (
-										<li class="flex gap-2 text-sm leading-relaxed text-slate-300/80 print:text-gray-700">
-											<span class="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-[#00ffff]/40 print:bg-gray-400" aria-hidden="true" />
-											{b}
-										</li>
-									))}
-								</ul>
-							</article>
-						))
-					}
+					{experience.map(({ title, org, period, bullets }) => (
+						<article class="blueprint-border rounded-md bg-black/35 p-5 print:border print:border-gray-300 print:bg-white print:break-inside-avoid">
+							<div class="mb-3 flex flex-wrap items-baseline justify-between gap-2">
+								<h3 class="font-orbitron text-sm uppercase tracking-[0.1em] text-cyan-100 print:text-black">{title}</h3>
+								<span class="font-tech text-[11px] uppercase tracking-[0.14em] text-cyan-300/50 print:text-gray-400">{period}</span>
+							</div>
+							<p class="font-tech text-[10px] uppercase tracking-[0.18em] text-[#39ff14]/70 mb-3 print:text-gray-500">{org}</p>
+							<ul class="space-y-2" role="list">
+								{bullets.map((b) => (
+									<li class="flex gap-2 text-sm leading-relaxed text-slate-300/80 print:text-gray-700">
+										<span class="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-[#00ffff]/40 print:bg-gray-400" aria-hidden="true" />
+										{b}
+									</li>
+								))}
+							</ul>
+						</article>
+					))}
 				</div>
 			</section>
 
 		</div>
 	</div>
 
-	<!-- Print styles -->
 	<style>
 		@media print {
-			body {
-				background: white !important;
-				color: black !important;
-			}
-			.bg-grid {
-				background-image: none !important;
-			}
-			nav {
-				display: none !important;
-			}
-			a[href]::after {
-				content: none !important;
-			}
+			body { background: white !important; color: black !important; }
+			.bg-grid { background-image: none !important; }
+			nav { display: none !important; }
+			a[href]::after { content: none !important; }
 		}
 	</style>
 </Layout>

--- a/src/pages/writing.astro
+++ b/src/pages/writing.astro
@@ -90,7 +90,7 @@ const bookSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" 
 										data-title={entry.data.title}
 										aria-label={`Read excerpt from ${entry.data.title}`}
 									>
-										<span set:html={penSvg} />
+										<span set:html={penSvg} aria-hidden="true" />
 										Read Excerpt
 									</button>
 								</div>
@@ -130,11 +130,13 @@ const bookSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" 
 		</div>
 	</div>
 
-	<script>
+	<script lang="ts">
 		const modal = document.getElementById('excerpt-modal') as HTMLElement;
 		const modalTitle = document.getElementById('modal-title') as HTMLElement;
 		const modalExcerpt = document.getElementById('modal-excerpt') as HTMLElement;
 		const closeBtn = document.getElementById('modal-close') as HTMLButtonElement;
+
+		let lastFocused: HTMLElement | null = null;
 
 		function openModal(title: string, excerpt: string) {
 			modalTitle.textContent = title;
@@ -147,10 +149,13 @@ const bookSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" 
 		function closeModal() {
 			modal.classList.add('hidden');
 			modal.classList.remove('flex');
+			lastFocused?.focus();
+			lastFocused = null;
 		}
 
 		document.querySelectorAll('.excerpt-trigger').forEach((btn) => {
 			btn.addEventListener('click', () => {
+				lastFocused = btn as HTMLElement;
 				const title = (btn as HTMLElement).dataset.title ?? '';
 				const excerpt = (btn as HTMLElement).dataset.excerpt ?? '';
 				openModal(title, excerpt);

--- a/src/pages/writing.astro
+++ b/src/pages/writing.astro
@@ -1,0 +1,170 @@
+---
+import Layout from '../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+
+const allWriting = await getCollection('writing');
+const sorted = allWriting.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+
+const statusConfig: Record<string, { label: string; classes: string }> = {
+	draft:     { label: 'DRAFT',     classes: 'border-[#39ff14]/40 text-[#39ff14]/80 bg-[#39ff14]/5' },
+	querying:  { label: 'QUERYING',  classes: 'border-[#00ffff]/40 text-[#00ffff]/80 bg-[#00ffff]/5' },
+	published: { label: 'PUBLISHED', classes: 'border-white/30 text-white/70 bg-white/5' },
+};
+
+// Inline SVGs
+const penSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>`;
+const bookSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/></svg>`;
+---
+
+<Layout
+	title="Writing | Sybilsedge"
+	description="Fiction portfolio — spy thrillers, works in progress, and completed projects."
+>
+	<div class="mx-auto w-full max-w-[1500px] px-4 py-6 md:px-8 md:py-10">
+
+		<!-- Page header -->
+		<header class="mb-8 rounded-md blueprint-border bg-black/35 p-5 md:p-8">
+			<p class="font-tech text-[11px] uppercase tracking-[0.22em] text-cyan-300/75">Portfolio</p>
+			<h1 class="font-orbitron mt-2 text-2xl uppercase tracking-[0.12em] text-cyan-100 md:text-4xl">
+				Writing
+			</h1>
+			<p class="mt-4 max-w-2xl text-base leading-relaxed text-slate-300/85">
+				Fiction projects — spy thrillers, works in progress, and anything else that escapes the terminal at night.
+			</p>
+		</header>
+
+		<!-- Status legend -->
+		<div class="mb-6 flex flex-wrap items-center gap-3">
+			<span class="font-tech text-[10px] uppercase tracking-[0.2em] text-cyan-300/40 mr-1">Status</span>
+			{Object.values(statusConfig).map(({ label, classes }) => (
+				<span class={`rounded border font-tech text-[10px] uppercase tracking-[0.14em] px-2 py-0.5 ${classes}`}>{label}</span>
+			))}
+		</div>
+
+		<!-- Writing cards -->
+		{sorted.length === 0 ? (
+			<div class="blueprint-border rounded-md bg-black/35 p-12 text-center">
+				<div class="mb-4 flex justify-center opacity-30" set:html={bookSvg} />
+				<p class="font-orbitron text-sm uppercase tracking-[0.16em] text-cyan-300/50">No projects yet</p>
+				<p class="mt-2 font-tech text-[11px] text-slate-400/60">Writing entries will appear here once added to the collection.</p>
+			</div>
+		) : (
+			<div class="grid grid-cols-1 gap-5 lg:grid-cols-2">
+				{sorted.map((entry) => {
+					const { label, classes } = statusConfig[entry.data.status];
+					const hasExcerpt = Boolean(entry.data.excerpt);
+					return (
+						<article
+							class="group blueprint-border rounded-md bg-black/35 p-6 transition-shadow duration-200 hover:shadow-[0_0_24px_rgba(0,255,255,0.07)] flex flex-col gap-4"
+							data-entry-id={entry.id}
+						>
+							<!-- Card top row -->
+							<div class="flex items-start justify-between gap-4">
+								<div class="flex items-center gap-2.5">
+									<span set:html={bookSvg} class="shrink-0 opacity-80" />
+									<h2 class="font-orbitron text-base uppercase tracking-[0.1em] text-cyan-100 leading-tight">
+										{entry.data.title}
+									</h2>
+								</div>
+								<span class={`shrink-0 rounded border font-tech text-[10px] uppercase tracking-[0.14em] px-2 py-0.5 ${classes}`}>
+									{label}
+								</span>
+							</div>
+
+							<!-- Genre + date -->
+							<div class="flex items-center gap-3">
+								<span class="font-tech text-[11px] uppercase tracking-[0.16em] text-[#00ffff]/60">{entry.data.genre}</span>
+								<span class="text-cyan-300/20">·</span>
+								<span class="font-tech text-[11px] text-cyan-300/40">{entry.data.date.getFullYear()}</span>
+							</div>
+
+							<!-- Synopsis -->
+							<p class="text-sm leading-relaxed text-slate-300/80">{entry.data.synopsis}</p>
+
+							<!-- Excerpt button -->
+							{hasExcerpt && (
+								<div class="mt-auto">
+									<button
+										class="excerpt-trigger flex items-center gap-2 font-tech text-[11px] uppercase tracking-[0.16em] text-[#39ff14]/70 hover:text-[#39ff14] transition-colors"
+										data-excerpt={entry.data.excerpt}
+										data-title={entry.data.title}
+										aria-label={`Read excerpt from ${entry.data.title}`}
+									>
+										<span set:html={penSvg} />
+										Read Excerpt
+									</button>
+								</div>
+							)}
+						</article>
+					);
+				})}
+			</div>
+		)}
+
+	</div>
+
+	<!-- Excerpt modal -->
+	<div
+		id="excerpt-modal"
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="modal-title"
+		class="fixed inset-0 z-50 hidden items-center justify-center p-4 bg-black/75 backdrop-blur-sm"
+	>
+		<div class="relative w-full max-w-2xl rounded-md blueprint-border bg-[#0a0a0a] p-8 shadow-[0_0_40px_rgba(0,255,255,0.08)]">
+			<!-- Close -->
+			<button
+				id="modal-close"
+				aria-label="Close excerpt"
+				class="absolute right-4 top-4 font-tech text-[11px] uppercase tracking-[0.16em] text-cyan-300/50 hover:text-cyan-300 transition-colors"
+			>
+				[ ESC ]
+			</button>
+			<!-- Header -->
+			<p class="font-tech text-[10px] uppercase tracking-[0.22em] text-cyan-300/50 mb-1">Excerpt</p>
+			<h3 id="modal-title" class="font-orbitron text-base uppercase tracking-[0.12em] text-cyan-100 mb-6"></h3>
+			<!-- Excerpt text -->
+			<div class="border-l-2 border-[#39ff14]/30 pl-5">
+				<p id="modal-excerpt" class="font-tech text-sm leading-relaxed text-slate-300/85 italic"></p>
+			</div>
+		</div>
+	</div>
+
+	<script>
+		const modal = document.getElementById('excerpt-modal') as HTMLElement;
+		const modalTitle = document.getElementById('modal-title') as HTMLElement;
+		const modalExcerpt = document.getElementById('modal-excerpt') as HTMLElement;
+		const closeBtn = document.getElementById('modal-close') as HTMLButtonElement;
+
+		function openModal(title: string, excerpt: string) {
+			modalTitle.textContent = title;
+			modalExcerpt.textContent = excerpt;
+			modal.classList.remove('hidden');
+			modal.classList.add('flex');
+			closeBtn.focus();
+		}
+
+		function closeModal() {
+			modal.classList.add('hidden');
+			modal.classList.remove('flex');
+		}
+
+		document.querySelectorAll('.excerpt-trigger').forEach((btn) => {
+			btn.addEventListener('click', () => {
+				const title = (btn as HTMLElement).dataset.title ?? '';
+				const excerpt = (btn as HTMLElement).dataset.excerpt ?? '';
+				openModal(title, excerpt);
+			});
+		});
+
+		closeBtn.addEventListener('click', closeModal);
+
+		modal.addEventListener('click', (e) => {
+			if (e.target === modal) closeModal();
+		});
+
+		document.addEventListener('keydown', (e) => {
+			if (e.key === 'Escape') closeModal();
+		});
+	</script>
+</Layout>


### PR DESCRIPTION
Several accessibility, correctness, and content issues flagged in review across the Writing, Projects, and Kitchen pages.

## ARIA

- **Filter buttons** (`projects.astro`, `kitchen.astro`): Replaced invalid `role="tablist"` / `role="tab"` / `aria-selected` pattern — there were no corresponding `tabpanel`s or arrow-key handling — with `role="group"` + `aria-pressed` on each button.
- **Decorative SVGs** (`about.astro`, `resume.astro`, `writing.astro`): Added `aria-hidden="true"` to inline SVG wrapper spans for pin, print, and pen icons, which had no useful label for screen readers.

## Script correctness

- Added `lang="ts"` to all three `<script>` blocks using TypeScript syntax (generics, type annotations, casts) in `projects.astro`, `kitchen.astro`, and `writing.astro`.
- Fixed `setFilter` in `projects.astro`: inactive buttons were getting `data-active=""` (attribute present, empty string), causing all buttons to match the `data-[active]:` selector. Now uses `removeAttribute('data-active')`.

## Modal accessibility (`writing.astro`)

Captures `document.activeElement` before opening the excerpt modal and restores focus on close — previously focus was lost to `<body>`:

```ts
let lastFocused: HTMLElement | null = null;

// on open:
lastFocused = btn as HTMLElement;

// on close:
lastFocused?.focus();
lastFocused = null;
```

## Cleanup

- Removed unused `getEntry` import (`projects/[slug].astro`) and unused `SectionHeader` import (`about.astro`).

## Content accuracy (`sybilsedge-site.md`, `about.astro`)

- Updated all "Astro 5" references to "Astro 6" to match `package.json`.
- Changed "Cloudflare Pages" to "Cloudflare Workers" to match the `wrangler.jsonc`-based deployment setup.
- Simplified "Astro 5" interest tag to "Astro" (version-agnostic).