### PR TITLE
implement #56 Maker Gallery from projects collection + update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Personal site for Sybil Melton — built with [Astro](https://astro.build) and d
 
 | Layer | Technology |
 | :------------ | :----------------------------------- |
-| Framework | Astro 5 (SSR, Cloudflare adapter) |
+| Framework | Astro 6 (SSR, Cloudflare adapter) |
 | Styling | Tailwind CSS v4 |
 | Deploy | Cloudflare Workers via Wrangler |
 | Content | Astro content collections |

--- a/README.md
+++ b/README.md
@@ -1,46 +1,83 @@
-# Astro Starter Kit: Basics
+# sybilsedge.com
 
-```sh
-npm create astro@latest -- --template basics
-```
+Personal site for Sybil Melton — built with [Astro](https://astro.build) and deployed on [Cloudflare Workers](https://workers.cloudflare.com).
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+## Stack
 
-## 🚀 Project Structure
+| Layer | Technology |
+| :------------ | :----------------------------------- |
+| Framework | Astro 5 (SSR, Cloudflare adapter) |
+| Styling | Tailwind CSS v4 |
+| Deploy | Cloudflare Workers via Wrangler |
+| Content | Astro content collections |
+| Runtime | `@astrojs/cloudflare` |
 
-Inside of your Astro project, you'll see the following folders and files:
+## Project Structure
 
 ```text
 /
-├── public/
-│   └── favicon.svg
-├── src
-│   ├── assets
-│   │   └── astro.svg
-│   ├── components
-│   │   └── Welcome.astro
-│   ├── layouts
-│   │   └── Layout.astro
-│   └── pages
-│       └── index.astro
+├── public/              # Static assets (favicon, fonts)
+├── src/
+│   ├── components/      # Astro components (TechCard, StatusFeed, etc.)
+│   ├── content/         # Content collection entries (.md files)
+│   │   ├── projects/
+│   │   ├── recipes/
+│   │   ├── writing/
+│   │   └── posts/
+│   ├── layouts/         # Base page layouts
+│   ├── pages/           # File-based routes
+│   └── content.config.ts  # Active content collection schemas
+├── wrangler.jsonc       # Cloudflare Workers config
 └── package.json
 ```
 
-To learn more about the folder structure of an Astro project, refer to [our guide on project structure](https://docs.astro.build/en/basics/project-structure/).
+## Local Development
 
-## 🧞 Commands
+```sh
+# Install dependencies
+npm install
 
-All commands are run from the root of the project, from a terminal:
+# Start dev server (localhost:4321)
+npm run dev
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
+# Build for production
+npm run build
 
-## 👀 Want to learn more?
+# Preview production build locally
+npm run preview
 
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+# Deploy to Cloudflare Workers
+npx wrangler deploy
+```
+
+## Environment Variables
+
+Runtime secrets are stored as **Cloudflare Worker secrets** — never committed to the repo.
+
+| Secret | Purpose | How to set |
+| :------------- | :---------------------------------------------- | :------------------------------------ |
+| `GITHUB_TOKEN` | Authenticated GitHub API requests (commit feed) | `npx wrangler secret put GITHUB_TOKEN` |
+
+To create the token: GitHub → Settings → Developer settings → Fine-grained tokens.
+Grant **Contents: Read-only** on the `sybilsedge/sybilsedge` repository.
+
+> Secrets set via `wrangler secret put` are automatically available at runtime —
+> no entry in `wrangler.jsonc` is required.
+
+## Content Collections
+
+All content lives in `src/content/` as Markdown files. Schemas are defined in `src/content.config.ts`.
+
+| Collection | Path | Key fields |
+| :--------- | :-------------------------- | :--------------------------------------- |
+| `projects` | `src/content/projects/` | `category`, `status`, `featured`, `progress` |
+| `recipes` | `src/content/recipes/` | `category`, `featured` |
+| `writing` | `src/content/writing/` | `status`, `wordCount`, `chapterStatus` |
+| `posts` | `src/content/posts/` | `draft`, `featured` |
+
+To feature a project in the Maker Gallery, set `featured: true` and optionally add a `progress` value (0–100) in the frontmatter.
+
+## Open Issues
+
+- **#60** — Migrate `GITHUB_TOKEN` access from `import.meta.env` to `Astro.locals.runtime.env`
+- **#61** — Investigate Cloudflare Cache/KV caching for the GitHub commit feed

--- a/src/components/BlueprintGallery.astro
+++ b/src/components/BlueprintGallery.astro
@@ -1,45 +1,56 @@
 ---
+import { getCollection } from 'astro:content';
 import TechCard from './TechCard.astro';
 import SectionHeader from './SectionHeader.astro';
 
-const builds = [
-	{
-		iconSvg: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 12-8.5 8.5c-.83.83-2.17.83-3 0 0 0 0 0 0 0a2.12 2.12 0 0 1 0-3L12 9"/><path d="M17.64 15 22 10.64"/><path d="m20.91 11.7-1.25-1.25c-.6-.6-.93-1.4-.93-2.25v-.86L16.01 4.6a5.56 5.56 0 0 0-3.94-1.64H9l.92.82A6.18 6.18 0 0 1 12 8.4v1.56l2 2h2.47l2.26 1.91"/></svg>`,
-		tag: 'WOODWORK',
-		title: 'Floating Cedar Bench',
-		body: 'Cantilever framing with hidden steel bracket channels.',
-		progress: 84,
-		featured: true,
-	},
-	{
-		iconSvg: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 10v.2A3 3 0 0 1 8.9 16H5a3 3 0 0 1-1-5.8V10a3 3 0 0 1 6 0Z"/><path d="M7 16v6"/><path d="M13 19v3"/><path d="M12 19h8.3a1 1 0 0 0 .7-1.7L18 14h.3a1 1 0 0 0 .7-1.7L16 9h.2a1 1 0 0 0 .8-1.7L13 3l-1.4 1.5"/></svg>`,
-		tag: 'GARDEN',
-		title: 'Rain Capture Trellis',
-		body: 'Gravity-fed line linked to herb-wall irrigation modules.',
-		progress: 62,
-	},
-	{
-		iconSvg: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.3 15.3a2.4 2.4 0 0 1 0 3.4l-2.6 2.6a2.4 2.4 0 0 1-3.4 0L2.7 8.7a2.41 2.41 0 0 1 0-3.4l2.6-2.6a2.41 2.41 0 0 1 3.4 0Z"/><path d="m14.5 12.5 2-2"/><path d="m11.5 9.5 2-2"/><path d="m8.5 6.5 2-2"/><path d="m17.5 15.5 2-2"/></svg>`,
-		tag: 'PROTOTYPE',
-		title: 'Workshop Tool Wall',
-		body: 'Grid-indexed hooks and magnetic rail in modular clusters.',
-		progress: 47,
-	},
-];
+// Pull featured projects, sorted newest-first
+// To feature a project in the gallery, set `featured: true` in its frontmatter.
+const allProjects = await getCollection('projects');
+const featured = allProjects
+	.filter((p) => p.data.featured)
+	.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
+	.slice(0, 4);
+
+// Category icon map
+const categoryIcons: Record<string, string> = {
+	tech: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>`,
+	home: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>`,
+	garden: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 11h.01"/><path d="M11 15h.01"/><path d="M16 16h.01"/><path d="m2 16 20 6-6-20A20 20 0 0 0 2 16"/><path d="M5.71 17.11a17.04 17.04 0 0 1 11.4-11.4"/></svg>`,
+};
 ---
 
 <section class="blueprint-border rounded-md bg-black/35 p-4 md:p-5">
 	<SectionHeader title="Maker Gallery" label="Analog Archive" />
 	<div class="space-y-3">
-		{builds.map((build) => (
-			<TechCard
-				tag={build.tag}
-				title={build.title}
-				body={build.body}
-				iconSvg={build.iconSvg}
-				progress={build.progress}
-				featured={build.featured}
-			/>
-		))}
+		{featured.length === 0 ? (
+			<!-- Blueprint placeholder — shown when no projects are featured yet -->
+			<div class="blueprint-border rounded-md bg-black/40 p-6">
+				<div class="flex flex-col items-center justify-center gap-3 text-center">
+					<!-- Schematic grid decoration -->
+					<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="text-cyan-300/20">
+						<rect x="1" y="1" width="46" height="46" rx="2" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3"/>
+						<line x1="24" y1="1" x2="24" y2="47" stroke="currentColor" stroke-width="0.5" stroke-dasharray="2 4"/>
+						<line x1="1" y1="24" x2="47" y2="24" stroke="currentColor" stroke-width="0.5" stroke-dasharray="2 4"/>
+						<circle cx="24" cy="24" r="6" stroke="currentColor" stroke-width="1"/>
+						<circle cx="24" cy="24" r="2" fill="currentColor"/>
+					</svg>
+					<p class="font-orbitron text-sm uppercase tracking-[0.08em] text-cyan-100/40">No builds featured</p>
+					<p class="font-tech text-[10px] uppercase tracking-[0.18em] text-cyan-300/30">Set featured: true in a project entry to populate this gallery</p>
+				</div>
+			</div>
+		) : (
+			featured.map((project) => (
+				<TechCard
+					tag={project.data.category.toUpperCase()}
+					title={project.data.title}
+					body={project.data.description}
+					iconSvg={categoryIcons[project.data.category] ?? categoryIcons.tech}
+					href={`/projects/${project.id}`}
+					featured={project.data.featured}
+					progress={project.data.progress}
+					footer={project.data.status.toUpperCase()}
+				/>
+			))
+		)}
 	</div>
 </section>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -32,6 +32,8 @@ const projects = defineCollection({
 		date: z.coerce.date(),
 		featured: z.boolean().default(false),
 		tags: z.array(z.string()).default([]),
+		// 0–100 completion percentage — renders a progress bar in the gallery card
+		progress: z.number().min(0).max(100).optional(),
 	}),
 });
 

--- a/src/content/projects/deck.md
+++ b/src/content/projects/deck.md
@@ -2,10 +2,11 @@
 title: "Back Deck Repaint"
 category: "home"
 status: "wip"
-description: "Repainting 400 sq ft deck."
+description: "Repainting 400 sq ft deck — stripping, sanding, priming, and painting after replacing rotted boards."
 image: ""
 date: 2026-03-01
-featured: false
+featured: true
+progress: 55
 tags: ["Painting", "Outdoor"]
 ---
 
@@ -21,6 +22,5 @@ Because of the weather, it has been a slow process.
 2. **Replaced rotted boards** — complete
 3. **Pressure wash** — complete
 4. **Sanding** — in progress
-5. **Priming** - upcoming
-6. **Painting** - upcoming
-
+5. **Priming** — upcoming
+6. **Painting** — upcoming

--- a/src/content/projects/sybilsedge-site.md
+++ b/src/content/projects/sybilsedge-site.md
@@ -1,27 +1,24 @@
 ---
-title: "Sybilsedge.com"
+title: "sybilsedge.com"
 category: "tech"
 status: "active"
-description: "Personal digital identity site built with Astro 6, Tailwind CSS, and deployed on Cloudflare Workers. Blueprint-cyberpunk aesthetic with zero JS by default and Astro Islands for interactive components."
+description: "Personal site built with Astro, deployed on Cloudflare Workers. Blueprint aesthetic with dark mode, content collections, and live GitHub activity feed."
 githubUrl: "https://github.com/sybilsedge/sybilsedge"
 image: ""
 date: 2026-04-01
 featured: true
-tags: ["Astro", "Tailwind", "Cloudflare", "TypeScript"]
+progress: 72
+tags: ["Astro", "Cloudflare", "TypeScript"]
 ---
 
 ## Overview
 
-This site is the project. Built in public on Cloudflare Workers using Astro 6 in SSR mode with the Cloudflare adapter. The design system is a blueprint-cyberpunk aesthetic — deep charcoal backgrounds, electric cyan and neon green accents, Orbitron headers, and a persistent CSS grid overlay that simulates a drafting board.
+Personal site and portfolio, built from scratch with Astro SSR deployed to Cloudflare Workers.
+Features a blueprint / dark sci-fi aesthetic with content collections for writing, projects, recipes, and posts.
 
 ## Stack
 
-- **Framework:** Astro 6 (SSR, `@astrojs/cloudflare`)
+- **Framework:** Astro 5 with Cloudflare adapter
 - **Styling:** Tailwind CSS v4
-- **Icons:** Inline SVG
-- **Data:** Astro Content Collections
-- **Deploy:** Cloudflare Workers
-
-## Status
-
-Active development. Building out content pillar pages iteratively.
+- **Deploy:** Cloudflare Workers via Wrangler
+- **Content:** Astro content collections (glob loader)

--- a/src/content/projects/sybilsedge-site.md
+++ b/src/content/projects/sybilsedge-site.md
@@ -18,7 +18,7 @@ Features a blueprint / dark sci-fi aesthetic with content collections for writin
 
 ## Stack
 
-- **Framework:** Astro 5 with Cloudflare adapter
+- **Framework:** Astro 6 with Cloudflare adapter
 - **Styling:** Tailwind CSS v4
 - **Deploy:** Cloudflare Workers via Wrangler
 - **Content:** Astro content collections (glob loader)


### PR DESCRIPTION
This pull request introduces several improvements to the project’s documentation, content organization, and Maker Gallery component. The main changes include a rewritten `README.md` with detailed stack and usage instructions, refactoring the Maker Gallery to pull featured projects dynamically from content collections, and updating project entries to include progress tracking and improved descriptions.

**Documentation and Developer Experience:**

* The `README.md` has been rewritten to describe the site’s purpose, stack, project structure, local development, environment variables, and content collection usage. It also lists open issues and provides clear instructions for contributors.

**Maker Gallery Refactor:**

* The `BlueprintGallery.astro` component now dynamically loads featured projects from the `projects` content collection, displaying up to four of the newest featured projects with their metadata and progress. A placeholder is shown if no projects are featured. Category icons are mapped programmatically.
* The `projects` content schema (`src/content.config.ts`) now supports an optional `progress` field (0–100), enabling progress bars in the gallery.

**Content Updates:**

* The `sybilsedge-site` project entry has an updated description, title, and now includes a `progress` field. The tags have been refined for accuracy.
* The `deck` project entry is now featured, includes a more descriptive summary, and tracks progress. Minor formatting improvements in the task list. [[1]](diffhunk://#diff-7735018babc37d1db63cf740317eb4c4edbef9ce3b9c09268a5f5857555d5cc2L5-R9) [[2]](diffhunk://#diff-7735018babc37d1db63cf740317eb4c4edbef9ce3b9c09268a5f5857555d5cc2L24-R26)

These changes improve maintainability, enable dynamic content in the Maker Gallery, and enhance the clarity and utility of project documentation.