### PR TITLE
add: characters

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -33,7 +33,7 @@ const characters = defineCollection({
 		role: z.string(),
 		description: z.string().optional(),
 		affiliation: z.array(z.string()).optional(),
-		appearance: z.string().optional(),
+		highlight: z.string().optional(),
 		profileImage: z.object({
 			src: image(),
 			alt: z.string(),

--- a/src/content/characters/katerina.mdx
+++ b/src/content/characters/katerina.mdx
@@ -5,9 +5,10 @@ role: antagonist-protagonist
 affiliation:
   - XAoC Cybernetics
   - Orlova Family
-appearance: "Late 40s. Sharp-featured and immaculate. She dresses like a closing argument and moves like she's already won."
+highlight: "Mercy without leverage gets people killed."
 spoilerLevel: light
 relatedCharacters:
+  - nikolai
   - yasutake
   - larisa-sokolova
 ---

--- a/src/content/characters/larisa-sokolova.mdx
+++ b/src/content/characters/larisa-sokolova.mdx
@@ -1,0 +1,69 @@
+---
+name: Larisa Sokolova
+universe: xaoc
+role: protagonist
+affiliation:
+  - XAoC Cybernetics
+  - Orlova Family
+spoilerLevel: light
+highlight: "Legitimacy only matters if you know how to defend it."
+relatedCharacters:
+  - katerina
+---
+
+## Overview
+
+Larisa Sokolova is Katerina Orlova’s second cousin and a cybersecurity and logistics analyst at XAoC. She begins as a principled insider who believes legitimate systems can and should be protected through order, process, and verification.
+
+Her arc is a moral descent in practical clothing: she starts as an idealist who trusts procedure, then learns that legitimacy sometimes survives only through ruthlessness, and ultimately becomes an effective operator inside the family structure she once tried to stand apart from.
+
+## Profile
+
+Larisa represents the ambitious, analytical side of the Orlova family. She wants the Orlova name to be respected in global tech, but she cannot fully escape the shadow of the empire behind it.
+
+She works in system defense and logistics integrity, which makes her both useful and vulnerable: she understands the infrastructure well enough to notice anomalies, but her loyalty makes her slow to believe the threat is internal. 
+
+## Appearance
+
+Larisa is in her mid twenties, with a practical corporate look that becomes sharper and more controlled as the story progresses. Her hair is typically tightly pulled back, especially under stress, and her clothing trends toward tailored suits and clean professional lines.
+
+Her body language shifts noticeably across the arc: at first tense, defensive, and brittle; later composed, assured, and severe. That visual change supports the internal transition from analyst to operator. 
+
+## Personality
+
+She is methodical, intelligent, and deeply verification-minded. Her defining habit is to check and re-check data before she trusts it, and she has a dry, controlled way of speaking when pressured. 
+
+Her flaw is blind loyalty to procedure and to the legitimacy project she wants to believe in. She trusts institutions too much at first, and that trust becomes her biggest vulnerability. 
+
+## Motivations
+
+Larisa wants order, legitimacy, and a version of the Orlova empire that can survive in public without shame. She does not want to be a criminal, but she also does not want to be powerless inside the family’s shadow. 
+
+After her first major mistake, her motivation shifts toward control. She becomes determined to prevent leaks, catch manipulations, and ensure that no one uses her systems, her company, or her family against her again. 
+
+## Strengths and flaws
+
+Her strengths are forensic thinking, attention to data integrity, and calm analytical reasoning under pressure. She is good at finding what doesn’t fit and narrowing the problem quickly. 
+
+Her flaws are naivety about insiders, overconfidence in process, and a tendency to confuse legitimacy with goodness. Once she is betrayed, she can swing hard toward cold pragmatism and moral compromise. 
+
+## Relationships
+
+Larisa is Katerina’s second cousin and one of the few family members who initially still believes in the “legitimate” face of XAoC. Katerina becomes both a mentor and a test case for what power looks like when it no longer bothers to pretend. 
+
+Her relationship with Chuman Patel is central to her public-facing storyline. She first treats him as a possible ally, then as a useful channel, and later as a tool she can force into correcting the narrative.
+
+Rostya Ilin is the key betrayer in her arc. He uses her trust in protocol and her respect for hierarchy to mislead her into framing the wrong man, which becomes the moment that permanently changes her. 
+
+## Character arc
+
+Larisa begins as an idealistic analyst who believes transparency and correct process can expose wrongdoing. When that belief is weaponized against her, she is forced to choose between naive whistleblowing and controlled, private countermeasures. 
+
+By the end, she accepts that legitimacy must be defended ruthlessly. She becomes a logistics operator who understands that truth, security, and power are all managed through narrative control as much as through evidence. 
+
+## Themes
+
+Larisa embodies the tension between legitimacy and corruption, and between truth as a value and truth as a weapon. She is compelling because her moral fall is also a practical rise. 
+
+She also represents the danger of trusting systems that look clean on the surface. Her arc shows that verification is not enough if the institution itself has already been compromised.
+

--- a/src/content/characters/nikolai.mdx
+++ b/src/content/characters/nikolai.mdx
@@ -1,0 +1,60 @@
+---
+name: Nikolai Molotov
+universe: xaoc
+role: supporting-family
+affiliation:
+  - Orlova Family
+highlight: "Passive defense keeps you comfortable. Active defense keeps you alive."
+spoilerLevel: light
+relatedCharacters:
+  - katerina
+  - alexei
+  - sofiya
+---
+
+## Overview
+
+Nikolai Molotov is Katerina Orlova's husband and the father of Alexei and Sofiya. Russian, early 50s, he is her field commander and the operational counterweight to her corporate and strategic authority, handling tactical security, active protection, and shadow operations.
+
+Former mercenary ("freelancer") in Thailand during the war, he became Katerina’s field commander when she rose as Pakhan of the Bratva. He becomes sharper in crisis, revealing a dormant operator. 
+
+## Profile
+
+Nikolai appears domesticated at home—husband, father, shaped by routine—but under pressure reveals disciplined instincts, quick judgment, and comfort with force. He fills the gap between legal protection and real protection against organized, violent threats. 
+
+He speaks to Katerina as an equal in family-defense matters, challenging her assumptions with practical directness. His role makes her private war operationally possible. 
+
+## Appearance
+
+Early 50s, Russian. Height: 6 feet 2 inches. Build: muscular, thick-set, broad-shouldered—imposing even for his age. Consistently clean-shaven/bald. Voice: deep, raspy, booming baritone. 
+
+He moves with sudden lethal grace in crisis, projecting competence over panic—like a dormant operator reactivated.
+
+## Personality
+
+Practical, direct, unsentimental about threats. He dismisses optics and corporate theater for offensive capability when passive systems fail. Balances Katerina with tactical clarity and decisiveness.
+
+## Motivations
+
+Central motivation: family protection through action. Not interested in institutional comfort when immediate danger demands interception over monitoring. Duty-bound within the family’s hidden operational structure. 
+
+## Strengths and flaws
+
+Strengths: tactical clarity, decisiveness under pressure, active-security thinking. Field knowledge and contacts enable quick violent response. 
+
+Flaws: extralegal force comfort, criminal infrastructure proximity, worldview normalizing dangerous methods for protective outcomes. 
+
+## Relationships
+
+Core: operational/intimate marriage with Katerina—mutual trust under pressure, covering blind spots. One of few challenging her as equal. 
+
+Father to Alexei/Sofiya: emotional anchor; crisis absence destabilizes household. Part of structure against Alexander. 
+
+## Character arc
+
+Revelation over transformation: story shows beneath husband/father is dangerous/capable man whose importance was concealed. Humanizes Katerina—her response to threats against him reveals personal stakes.
+
+## Themes
+
+Active protection, embodied competence, institutional distrust cost. Security ≠ legality. What protecting loved ones from monstrous systems demands. 
+

--- a/src/content/characters/yasutake.mdx
+++ b/src/content/characters/yasutake.mdx
@@ -4,12 +4,63 @@ universe: xaoc
 role: protagonist
 affiliation:
   - ICPO Counter-Terrorism
-appearance: "Early 40s. His left arm is a matte-black XAoC Mk-7 unit — he never covers it. Methodical in the field, brutal in the margins of his case files."
+highlight: "Precision is not safety. Sometimes it is paralysis."
+spoilerLevel: light
 relatedCharacters:
   - katerina
-  - larisa-sokolova
 ---
 
-ICPO Counter-Terrorism analyst assigned to what looks like a straightforward bombing claim by the RBLA. It isn't. His own cybernetic arm — an XAoC unit installed after a mission in Minsk — makes the investigation uncomfortably personal.
+## Overview
 
-Yasutake is the first to recognize the contradiction at the heart of the case: precision-engineered prosthetics sabotaged with deliberately crude trigger mechanisms. Someone inside XAoC's supply chain wanted this to look like terrorism. He intends to find out why.
+Yasutake Masanori is a 42-year-old former Japanese detective and current ICPO counter-terrorism analyst. Defined by meticulous control born from trauma, he is one of the novel's dual protagonists alongside Larisa Sokolova.
+
+He begins as a procedural specialist paralyzed by risk aversion but evolves into a pragmatic operative willing to collaborate with morally ambiguous allies like Katerina Orlova to stop existential threats. 
+
+## Profile
+
+Publicly, Yasutake presents as unflappable, hyper-efficient, and analytically precise. He operates like a specialized machine, coldly effective with data but prone to emotional paralysis when facing unpredictable human factors. 
+
+Privately, he battles acute anxiety, compulsive rituals, and a haunted psyche trapped in an immortal synthetic body. His need for order extends to compulsive cleaning and geometric precision as proxies for internal control he cannot achieve.
+
+## Appearance
+
+Yasutake has a full cybernetic body following a traumatic RBLA bombing that destroyed his organic form. Mid-forties, composed, with synthetic prosthetics noted in his left arm; clinical manner and obsessive attention to order. 
+
+He appears achromatic—emotionally and physically precise, haunted, with a fastidious presentation that seeks aesthetic harmony through ritualistic tidiness. Quirks include straightening picture frames and aligning monitors perfectly.
+
+## Personality
+
+Compulsive, detail-obsessed, risk-averse, and rationally detached as defense. He is a traumatized perfectionist whose meticulousness masks constant internal anxiety and second-guessing. 
+
+Fastidious and micro-managerial, he seeks comfort in geometric precision and repetition, particularly within his sterile office. Emotionally guarded with soft humor in rare moments of pressure.
+
+## Motivations
+
+Yasutake wants to protect the public from cybernetic terror and restore secure, lawful processes. His deeper need is to overcome procedural paralysis and take decisive action against realistic threats, even through extralegal means. 
+
+Trauma from the RBLA bombing drives his conflicts between duty and self-preservation, machine identity versus humanity, and attachment versus avoidance.
+
+## Strengths and flaws
+
+His forensic cyber-signature analysis, meticulous pattern recognition, and analytical precision make him invaluable for complex investigations. He excels at data organization and threat assessment. 
+
+Flaws include over-reliance on procedure, hesitation under chaos, pathological risk-aversion, and anxiety-induced paralysis. His synthetic precision contrasts with fundamentally human indecisiveness. 
+
+## Relationships
+
+Yasutake forms a frictional alliance with Katerina Orlova: she pushes narrative speed while he demands verification. He respects her competence despite disagreements and is one of few who can challenge her without dismissal. 
+
+He writes unsent emails to his daughter, overridden by fear of vulnerability. Duty conflicts with self-preservation, keeping him isolated yet professionally driven.
+
+## Character arc
+
+Yasutake starts as a by-the-book analyst confined to desk work, paralyzed by procedure during existential threats. He evolves into a pragmatic agent accepting morally complicated cooperation, acting outside chain-of-command. 
+
+His positive arc maps growth from rigid protocol to effective action in a corrupt world, confronting trauma through RBLA cases and split-second choices based on insufficient data. 
+
+## Themes
+
+Yasutake embodies the tension between precision and paralysis, machine perfection versus human fragility. He questions whether over-analysis ensures safety or enables harm through inaction.
+
+As the Reluctant Reformer, he learns pragmatic courage complements intellectual integrity, evolving from analyst to hero through duty versus effectiveness.
+

--- a/src/pages/writing/characters/[slug].astro
+++ b/src/pages/writing/characters/[slug].astro
@@ -96,9 +96,9 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? 'https://sybilsed
 				</div>
 			)}
 
-			{entry.data.appearance && (
+			{entry.data.highlight && (
 				<p class="mt-4 font-tech text-sm italic leading-relaxed text-slate-400/70 border-l-2 border-[#39ff14]/25 pl-4">
-					{entry.data.appearance}
+					{entry.data.highlight}
 				</p>
 			)}
 		</header>


### PR DESCRIPTION
This pull request introduces significant updates to the character data model and content for the "xaoc" universe. The main changes include replacing the `appearance` field with a more thematic `highlight` field across character definitions, updating the character pages to use this new field, and adding two new, detailed character profiles.

**Schema and Data Model Updates:**

* Replaced the `appearance` field with a `highlight` field in the `characters` collection schema in `src/content.config.ts`, shifting focus from physical description to a key quote or thematic summary.

**Character Content Updates:**

* Updated existing character files (`katerina.mdx`, `yasutake.mdx`) to use the new `highlight` field instead of `appearance`, and expanded their profiles with richer thematic and narrative information. [[1]](diffhunk://#diff-6bbab53d4cc75392ea03ca63dccdb8bf1fa64190521e28374259535ef0bfddf6L8-R11) [[2]](diffhunk://#diff-da8bdbc3da718c0367f7c5206340eaf9c085c0a6434a2752ca9685030a69d24dL7-L15)
* Added new, in-depth character profiles for `Larisa Sokolova` and `Nikolai Molotov`, including background, appearance, personality, motivations, relationships, and narrative arcs. [[1]](diffhunk://#diff-3af65a379f39a8508a08fffd990acd87c6222128cc6d98e813e0d42553378161R1-R69) [[2]](diffhunk://#diff-9574c09d6298deed841a190bdfd57290d4b1adc025d55ec4b27919f178c271dfR1-R60)

**UI/Template Adjustments:**

* Modified the character page template (`[slug].astro`) to display the `highlight` field instead of `appearance`, ensuring the new schema is reflected in the UI. ([src/pages/writing/characters/[slug].astroL99-R101](diffhunk://#diff-cfbc564ca74bef8a07bc809f168ea9fa5e9d0e2973cfd57665bebc34085a7028L99-R101))