### PR TITLE
feat: refactor color token

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -59,7 +59,7 @@ const isWritingActive = currentPath.startsWith('/writing');
 	<div class="mx-auto flex w-full max-w-[1500px] items-center justify-between px-4 py-3 md:px-8">
 		<!-- Wordmark -->
 		<a href="/" class="flex items-center gap-2 no-underline" aria-label="Sybilsedge home">
-			<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+			<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" class="text-accent">
 				<polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
 			</svg>
 			<span class="font-orbitron text-sm font-bold uppercase tracking-[0.2em] text-cyan-100">

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -78,7 +78,7 @@ const isWritingActive = currentPath.startsWith('/writing');
 								href={href}
 								class={`flex items-center gap-1.5 rounded px-3 py-1.5 font-tech text-[11px] uppercase tracking-[0.16em] transition-colors duration-150 ${
 									isActive
-										? 'text-[#39ff14] neon-border bg-[#39ff14]/5'
+										? 'text-accent neon-border bg-accent/5'
 										: 'text-cyan-300/70 hover:text-cyan-100 hover:bg-white/5'
 								}`}
 								aria-current={isActive ? 'page' : undefined}
@@ -97,7 +97,7 @@ const isWritingActive = currentPath.startsWith('/writing');
 					href="/writing/"
 					class={`flex items-center gap-1.5 rounded px-3 py-1.5 font-tech text-[11px] uppercase tracking-[0.16em] transition-colors duration-150 ${
 						isWritingActive
-							? 'text-[#39ff14] neon-border bg-[#39ff14]/5'
+							? 'text-accent neon-border bg-accent/5'
 							: 'text-cyan-300/70 hover:text-cyan-100 hover:bg-white/5'
 					}`}
 					aria-current={isWritingActive ? 'page' : undefined}
@@ -124,7 +124,7 @@ const isWritingActive = currentPath.startsWith('/writing');
 									href={href}
 									class={`flex items-center rounded px-3 py-1.5 font-tech text-[11px] uppercase tracking-[0.14em] transition-colors ${
 										isSubActive
-											? 'text-[#39ff14] bg-[#39ff14]/5'
+											? 'text-accent bg-accent/5'
 											: 'text-cyan-300/60 hover:text-cyan-100 hover:bg-white/5'
 									}`}
 									aria-current={isSubActive ? 'page' : undefined}
@@ -146,7 +146,7 @@ const isWritingActive = currentPath.startsWith('/writing');
 								href={href}
 								class={`flex items-center gap-1.5 rounded px-3 py-1.5 font-tech text-[11px] uppercase tracking-[0.16em] transition-colors duration-150 ${
 									isActive
-										? 'text-[#39ff14] neon-border bg-[#39ff14]/5'
+										? 'text-accent neon-border bg-accent/5'
 										: 'text-cyan-300/70 hover:text-cyan-100 hover:bg-white/5'
 								}`}
 								aria-current={isActive ? 'page' : undefined}
@@ -187,7 +187,7 @@ const isWritingActive = currentPath.startsWith('/writing');
 							<a
 								href={href}
 								class={`flex items-center gap-2 rounded px-3 py-2 font-tech text-[11px] uppercase tracking-[0.16em] transition-colors ${
-									isActive ? 'text-[#39ff14] bg-[#39ff14]/5' : 'text-cyan-300/70 hover:text-cyan-100 hover:bg-white/5'
+									isActive ? 'text-accent bg-accent/5' : 'text-cyan-300/70 hover:text-cyan-100 hover:bg-white/5'
 								}`}
 								aria-current={isActive ? 'page' : undefined}
 							>
@@ -203,7 +203,7 @@ const isWritingActive = currentPath.startsWith('/writing');
 					<a
 						href="/writing/"
 						class={`flex items-center gap-2 rounded px-3 py-2 font-tech text-[11px] uppercase tracking-[0.16em] transition-colors ${
-							isWritingActive ? 'text-[#39ff14] bg-[#39ff14]/5' : 'text-cyan-300/70 hover:text-cyan-100 hover:bg-white/5'
+							isWritingActive ? 'text-accent bg-accent/5' : 'text-cyan-300/70 hover:text-cyan-100 hover:bg-white/5'
 						}`}
 						aria-current={isWritingActive ? 'page' : undefined}
 					>
@@ -219,7 +219,7 @@ const isWritingActive = currentPath.startsWith('/writing');
 							<a
 								href={href}
 								class={`flex items-center rounded pl-8 pr-3 py-1.5 font-tech text-[10px] uppercase tracking-[0.14em] transition-colors ${
-									isSubActive ? 'text-[#39ff14]/80 bg-[#39ff14]/5' : 'text-cyan-300/50 hover:text-cyan-100 hover:bg-white/5'
+									isSubActive ? 'text-accent/80 bg-accent/5' : 'text-cyan-300/50 hover:text-cyan-100 hover:bg-white/5'
 								}`}
 								aria-current={isSubActive ? 'page' : undefined}
 							>
@@ -237,7 +237,7 @@ const isWritingActive = currentPath.startsWith('/writing');
 							<a
 								href={href}
 								class={`flex items-center gap-2 rounded px-3 py-2 font-tech text-[11px] uppercase tracking-[0.16em] transition-colors ${
-									isActive ? 'text-[#39ff14] bg-[#39ff14]/5' : 'text-cyan-300/70 hover:text-cyan-100 hover:bg-white/5'
+									isActive ? 'text-accent bg-accent/5' : 'text-cyan-300/70 hover:text-cyan-100 hover:bg-white/5'
 								}`}
 								aria-current={isActive ? 'page' : undefined}
 							>

--- a/src/components/StepGallery.tsx
+++ b/src/components/StepGallery.tsx
@@ -169,8 +169,8 @@ export default function StepGallery({ items, label }: Props) {
 						/>
 
 						{/* Step number badge — top-left */}
-						<div className="absolute left-1.5 top-1.5 z-10 flex h-5 w-5 items-center justify-center rounded border border-[#39ff14]/40 bg-black/70">
-							<span className="font-orbitron text-[8px] font-semibold leading-none text-[#39ff14]/80">
+						<div className="absolute left-1.5 top-1.5 z-10 flex h-5 w-5 items-center justify-center rounded border border-accent/40 bg-black/70">
+							<span className="font-orbitron text-[8px] font-semibold leading-none text-accent/80">
 								{idx + 1}
 							</span>
 						</div>

--- a/src/components/TechCard.astro
+++ b/src/components/TechCard.astro
@@ -19,6 +19,7 @@ interface Props {
 	title: string;
 	body: string;
 	iconSvg?: string;
+	iconClass?: string;
 	href?: string;
 	footer?: string;
 	featured?: boolean;
@@ -30,6 +31,7 @@ const {
 	title,
 	body,
 	iconSvg,
+	iconClass = 'text-cyan-300',
 	href,
 	footer,
 	featured = false,
@@ -55,7 +57,7 @@ const clampedProgress =
 		<div class="flex items-center justify-between">
 			<div class="flex items-center gap-2">
 				{iconSvg && (
-					<span aria-hidden="true" class="text-cyan-300 flex-shrink-0" set:html={iconSvg} />
+					<span aria-hidden="true" class={`${iconClass} flex-shrink-0`} set:html={iconSvg} />
 				)}
 				<p class="font-tech text-[11px] uppercase tracking-[0.18em] text-cyan-300/80">{tag}</p>
 			</div>

--- a/src/components/TechCard.astro
+++ b/src/components/TechCard.astro
@@ -8,6 +8,9 @@
  *   body       — body text (Inter)
  *   iconSvg?   — inline SVG string for the tag icon (TRUSTED INTERNAL SOURCES ONLY;
  *                never pass user-supplied strings — rendered via set:html)
+ *   iconClass? — Tailwind text-color class applied to the icon wrapper span
+ *                (default: 'text-cyan-300'). Use 'text-accent' or 'text-primary'
+ *                to align with the semantic token cascade.
  *   href?      — optional card link; rendered as an overlay <a> to avoid nested
  *                interactive elements when the slot contains links/buttons
  *   footer?    — optional bottom-right text (e.g. date, progress %)

--- a/src/components/writing/CategoryBadge.astro
+++ b/src/components/writing/CategoryBadge.astro
@@ -12,7 +12,7 @@ const { category } = Astro.props;
 const config: Record<string, { label: string; classes: string }> = {
 	location:   { label: 'Location',   classes: 'border-amber-400/40 text-amber-400/80 bg-amber-400/5' },
 	faction:    { label: 'Faction',    classes: 'border-rose-400/40 text-rose-400/80 bg-rose-400/5' },
-	technology: { label: 'Technology', classes: 'border-[#00ffff]/40 text-[#00ffff]/80 bg-[#00ffff]/5' },
+	technology: { label: 'Technology', classes: 'border-primary/40 text-primary/80 bg-primary/5' },
 	history:    { label: 'History',    classes: 'border-slate-400/40 text-slate-400/80 bg-slate-400/5' },
 	culture:    { label: 'Culture',    classes: 'border-violet-400/40 text-violet-400/80 bg-violet-400/5' },
 	other:      { label: 'Other',      classes: 'border-cyan-300/20 text-cyan-300/50 bg-transparent' },

--- a/src/components/writing/CharacterCard.astro
+++ b/src/components/writing/CharacterCard.astro
@@ -20,7 +20,7 @@ const arrowSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11"
 	class="group blueprint-border rounded-md bg-black/35 p-4 flex flex-col gap-2 transition-shadow duration-200 hover:shadow-[0_0_20px_rgba(0,255,255,0.07)] hover:bg-black/50"
 >
 	<div class="flex items-center gap-2">
-		<span set:html={personSvg} class="shrink-0 text-[#39ff14]/70 group-hover:text-[#39ff14] transition-colors" />
+		<span set:html={personSvg} class="shrink-0 text-accent/70 group-hover:text-accent transition-colors" />
 		<span class="font-orbitron text-sm uppercase tracking-[0.1em] text-cyan-100 leading-tight group-hover:text-cyan-300 transition-colors truncate">
 			{character.data.name}
 		</span>
@@ -30,7 +30,7 @@ const arrowSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11"
 		<span class="font-tech text-[10px] uppercase tracking-[0.14em] text-cyan-300/50 truncate">
 			{character.data.role}
 		</span>
-		<span set:html={arrowSvg} class="shrink-0 text-cyan-300/30 group-hover:text-[#39ff14]/60 transition-colors" />
+		<span set:html={arrowSvg} class="shrink-0 text-cyan-300/30 group-hover:text-accent/60 transition-colors" />
 	</div>
 
 	{character.data.affiliation && character.data.affiliation.length > 0 && (

--- a/src/components/writing/LoreCard.astro
+++ b/src/components/writing/LoreCard.astro
@@ -29,7 +29,7 @@ const arrowSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11"
 		{entry.data.universe}
 	</span>
 
-	<div class="mt-auto flex items-center gap-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-cyan-300/40 group-hover:text-[#39ff14]/70 transition-colors">
+	<div class="mt-auto flex items-center gap-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-cyan-300/40 group-hover:text-accent/70 transition-colors">
 		View Entry
 		<span set:html={arrowSvg} />
 	</div>

--- a/src/components/writing/NovelCard.astro
+++ b/src/components/writing/NovelCard.astro
@@ -25,7 +25,7 @@ const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11"
 >
 	<div class="flex items-start justify-between gap-3">
 		<div class="flex items-center gap-2.5">
-			<span set:html={bookSvg} class="shrink-0 text-[#39ff14]/70 group-hover:text-[#39ff14] transition-colors" />
+			<span set:html={bookSvg} class="shrink-0 text-accent/70 group-hover:text-accent transition-colors" />
 			<h2 class="font-orbitron text-base uppercase tracking-[0.1em] text-cyan-100 leading-tight group-hover:text-cyan-300 transition-colors">
 				{novel.data.title}
 			</h2>
@@ -56,7 +56,7 @@ const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11"
 		{novel.data.synopsis}
 	</p>
 
-	<div class="mt-auto flex items-center gap-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-cyan-300/40 group-hover:text-[#39ff14]/70 transition-colors">
+	<div class="mt-auto flex items-center gap-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-cyan-300/40 group-hover:text-accent/70 transition-colors">
 		Read More
 		<span set:html={arrowSvg} />
 	</div>

--- a/src/components/writing/ReadingOrderItem.astro
+++ b/src/components/writing/ReadingOrderItem.astro
@@ -14,8 +14,8 @@ interface Props {
 const { title, type, href, readingOrder, synopsis } = Astro.props;
 
 const typeBadgeClasses = type === 'novel'
-	? 'border-[#39ff14]/35 text-[#39ff14]/70 bg-[#39ff14]/5'
-	: 'border-[#00ffff]/35 text-[#00ffff]/70 bg-[#00ffff]/5';
+	? 'border-accent/35 text-accent/70 bg-accent/5'
+	: 'border-primary/35 text-primary/70 bg-primary/5';
 
 const typeLabel = type === 'novel' ? 'Novel' : 'Short Story';
 
@@ -29,7 +29,7 @@ const arrowSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11"
 	>
 		<!-- Reading order number -->
 		{readingOrder !== undefined && (
-			<span class="shrink-0 font-orbitron text-lg text-[#39ff14]/40 group-hover:text-[#39ff14]/70 transition-colors w-8 text-right">
+			<span class="shrink-0 font-orbitron text-lg text-accent/40 group-hover:text-accent/70 transition-colors w-8 text-right">
 				{readingOrder}
 			</span>
 		)}
@@ -46,6 +46,6 @@ const arrowSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11"
 			<p class="font-tech text-[11px] text-slate-400/60 line-clamp-1">{synopsis}</p>
 		</div>
 
-		<span set:html={arrowSvg} class="shrink-0 self-center text-cyan-300/25 group-hover:text-[#39ff14]/60 transition-colors" />
+		<span set:html={arrowSvg} class="shrink-0 self-center text-cyan-300/25 group-hover:text-accent/60 transition-colors" />
 	</a>
 </li>

--- a/src/components/writing/StatsBar.astro
+++ b/src/components/writing/StatsBar.astro
@@ -21,7 +21,7 @@ const stats = [
 <div class="flex flex-wrap gap-4">
 	{stats.map(({ label, value }) => (
 		<div class="blueprint-border rounded-md bg-black/35 px-5 py-3 flex flex-col items-center gap-0.5 min-w-[80px]">
-			<span class="font-orbitron text-xl text-[#39ff14]">{value}</span>
+			<span class="font-orbitron text-xl text-accent">{value}</span>
 			<span class="font-tech text-[10px] uppercase tracking-[0.18em] text-cyan-300/55">{label}</span>
 		</div>
 	))}

--- a/src/components/writing/StatusBadge.astro
+++ b/src/components/writing/StatusBadge.astro
@@ -16,8 +16,8 @@ interface Props {
 const { status } = Astro.props;
 
 const config: Record<string, { label: string; classes: string }> = {
-	'draft':       { label: 'DRAFT',       classes: 'border-[#39ff14]/40 text-[#39ff14]/80 bg-[#39ff14]/5' },
-	'in-progress': { label: 'IN PROGRESS', classes: 'border-[#00ffff]/40 text-[#00ffff]/80 bg-[#00ffff]/5' },
+	'draft':       { label: 'DRAFT',       classes: 'border-accent/40 text-accent/80 bg-accent/5' },
+	'in-progress': { label: 'IN PROGRESS', classes: 'border-primary/40 text-primary/80 bg-primary/5' },
 	'complete':    { label: 'COMPLETE',    classes: 'border-white/25 text-white/60 bg-white/5' },
 	'published':   { label: 'PUBLISHED',   classes: 'border-white/40 text-white/80 bg-white/5' },
 };

--- a/src/components/writing/StoryCard.astro
+++ b/src/components/writing/StoryCard.astro
@@ -22,7 +22,7 @@ const arrowSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11"
 	class="group blueprint-border rounded-md bg-black/35 p-5 flex flex-col gap-3 transition-shadow duration-200 hover:shadow-[0_0_20px_rgba(0,255,255,0.07)] hover:bg-black/50"
 >
 	<div class="flex items-start gap-2.5">
-		<span set:html={penSvg} class="shrink-0 text-[#39ff14]/70 group-hover:text-[#39ff14] transition-colors mt-0.5" />
+		<span set:html={penSvg} class="shrink-0 text-accent/70 group-hover:text-accent transition-colors mt-0.5" />
 		<h2 class="font-orbitron text-sm uppercase tracking-[0.1em] text-cyan-100 leading-tight group-hover:text-cyan-300 transition-colors">
 			{story.data.title}
 		</h2>
@@ -54,7 +54,7 @@ const arrowSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11"
 		</div>
 	)}
 
-	<div class="mt-auto flex items-center gap-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-cyan-300/40 group-hover:text-[#39ff14]/70 transition-colors">
+	<div class="mt-auto flex items-center gap-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-cyan-300/40 group-hover:text-accent/70 transition-colors">
 		Read Story
 		<span set:html={arrowSvg} />
 	</div>

--- a/src/components/writing/TimelineEvent.astro
+++ b/src/components/writing/TimelineEvent.astro
@@ -31,7 +31,7 @@ const {
 <div class="relative pl-8" id={`event-${slug}`}>
 	<!-- Node dot on the rail -->
 	<div
-		class="absolute left-0 top-1.5 h-3 w-3 rounded-full bg-[#39ff14]/60 border border-[#39ff14]/30 shadow-[0_0_8px_rgba(57,255,20,0.3)]"
+		class="absolute left-0 top-1.5 h-3 w-3 rounded-full bg-accent/60 border border-accent/30 shadow-[0_0_8px_color-mix(in_srgb,var(--neon-green)_30%,transparent)]"
 		aria-hidden="true"
 	></div>
 
@@ -46,7 +46,7 @@ const {
 		</div>
 
 		{era && (
-			<span class="font-tech text-[10px] uppercase tracking-[0.16em] text-[#39ff14]/55">{era}</span>
+			<span class="font-tech text-[10px] uppercase tracking-[0.16em] text-accent/55">{era}</span>
 		)}
 
 		<p class="text-sm leading-relaxed text-slate-300/75">{summary}</p>

--- a/src/components/writing/TimelineEvent.astro
+++ b/src/components/writing/TimelineEvent.astro
@@ -31,7 +31,7 @@ const {
 <div class="relative pl-8" id={`event-${slug}`}>
 	<!-- Node dot on the rail -->
 	<div
-		class="absolute left-0 top-1.5 h-3 w-3 rounded-full bg-accent/60 border border-accent/30 shadow-[0_0_8px_color-mix(in_srgb,var(--neon-green)_30%,transparent)]"
+		class="absolute left-0 top-1.5 h-3 w-3 rounded-full bg-accent/60 border border-accent/30 shadow-[0_0_8px_color-mix(in_srgb,var(--color-accent)_30%,transparent)]"
 		aria-hidden="true"
 	></div>
 

--- a/src/components/writing/UniverseCard.astro
+++ b/src/components/writing/UniverseCard.astro
@@ -17,7 +17,7 @@ const globeSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
 const arrowSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>`;
 
 const statusClasses: Record<string, string> = {
-	active:   'border-[#39ff14]/40 text-[#39ff14]/80 bg-[#39ff14]/5',
+	active:   'border-accent/40 text-accent/80 bg-accent/5',
 	planned:  'border-cyan-300/25 text-cyan-300/50 bg-transparent',
 	archived: 'border-slate-500/30 text-slate-500/50 bg-slate-500/5',
 };
@@ -30,7 +30,7 @@ const statusClasses: Record<string, string> = {
 	>
 		<div class="flex items-start justify-between gap-3">
 			<div class="flex items-center gap-2.5">
-				<span set:html={globeSvg} class="shrink-0 text-[#39ff14]/70 group-hover:text-[#39ff14] transition-colors" />
+				<span set:html={globeSvg} class="shrink-0 text-accent/70 group-hover:text-accent transition-colors" />
 				<h2 class="font-orbitron text-base uppercase tracking-[0.1em] text-cyan-100 leading-tight group-hover:text-cyan-300 transition-colors">
 					{universe.data.name}
 				</h2>
@@ -40,7 +40,7 @@ const statusClasses: Record<string, string> = {
 			</span>
 		</div>
 
-		<p class="font-tech text-xs italic text-[#39ff14]/70 leading-snug">
+		<p class="font-tech text-xs italic text-accent/70 leading-snug">
 			{universe.data.tagline}
 		</p>
 
@@ -48,7 +48,7 @@ const statusClasses: Record<string, string> = {
 			{universe.data.description}
 		</p>
 
-		<div class="mt-auto flex items-center gap-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-cyan-300/50 group-hover:text-[#39ff14]/70 transition-colors">
+		<div class="mt-auto flex items-center gap-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-cyan-300/50 group-hover:text-accent/70 transition-colors">
 			Explore Universe
 			<span set:html={arrowSvg} />
 		</div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -5,32 +5,36 @@ import { bio, timeline, interests } from '../data/about';
 
 const pillars = [
 	{
-		iconSvg: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>`,
+		iconSvg: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>`,
+		iconClass: 'text-accent',
 		label: 'Writing',
 		description: 'Sci-fi thrillers with technical depth. Characters shaped by tradecraft, loss, and the weight of knowing too much.',
 		tag: 'FICTION',
 	},
 	{
-		iconSvg: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#00ffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><path d="M15 2v2"/><path d="M15 20v2"/><path d="M2 15h2"/><path d="M2 9h2"/><path d="M20 15h2"/><path d="M20 9h2"/><path d="M9 2v2"/><path d="M9 20v2"/></svg>`,
+		iconSvg: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><path d="M15 2v2"/><path d="M15 20v2"/><path d="M2 15h2"/><path d="M2 9h2"/><path d="M20 15h2"/><path d="M20 9h2"/><path d="M9 2v2"/><path d="M9 20v2"/></svg>`,
+		iconClass: 'text-primary',
 		label: 'Tech & Cloud',
 		description: '19+ years architecting enterprise systems. GCP-certified. Specialising in cloud, networking, security, and observability.',
 		tag: 'ARCHITECTURE',
 	},
 	{
-		iconSvg: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 12-8.5 8.5c-.83.83-2.17.83-3 0 0 0 0 0 0 0a2.12 2.12 0 0 1 0-3L12 9"/><path d="M17.64 15 22 10.64"/><path d="m20.91 11.7-1.25-1.25c-.6-.6-.93-1.4-.93-2.25v-.86L16.01 4.6a5.56 5.56 0 0 0-3.94-1.64H9l.92.82A6.18 6.18 0 0 1 12 8.4v1.56l2 2h2.47l2.26 1.91"/></svg>`,
+		iconSvg: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 12-8.5 8.5c-.83.83-2.17.83-3 0 0 0 0 0 0 0a2.12 2.12 0 0 1 0-3L12 9"/><path d="M17.64 15 22 10.64"/><path d="m20.91 11.7-1.25-1.25c-.6-.6-.93-1.4-.93-2.25v-.86L16.01 4.6a5.56 5.56 0 0 0-3.94-1.64H9l.92.82A6.18 6.18 0 0 1 12 8.4v1.56l2 2h2.47l2.26 1.91"/></svg>`,
+		iconClass: 'text-accent',
 		label: 'Maker & Home',
 		description: 'Home improvement projects, electronics tinkering, gardening, and the satisfaction of building things with your hands.',
 		tag: 'MAKER',
 	},
 	{
-		iconSvg: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#00ffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2"/><path d="M7 2v20"/><path d="M21 15V2a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3Zm0 0v7"/></svg>`,
+		iconSvg: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2"/><path d="M7 2v20"/><path d="M21 15V2a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3Zm0 0v7"/></svg>`,
+		iconClass: 'text-primary',
 		label: 'Kitchen',
 		description: 'Sourdough. Slow braises. Fermentation experiments. Cooking as engineering — precise, iterative, occasionally explosive.',
 		tag: 'CULINARY',
 	},
 ];
 
-const zapSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>`;
+const zapSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>`;
 const pinSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>`;
 ---
 
@@ -69,6 +73,7 @@ const pinSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" v
 						title={pillar.label}
 						body={pillar.description}
 						iconSvg={pillar.iconSvg}
+						iconClass={pillar.iconClass}
 					/>
 				))}
 			</div>
@@ -83,8 +88,8 @@ const pinSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" v
 			<div class="relative border-l border-cyan-300/20 pl-6 space-y-6">
 				{timeline.map(({ year, event }) => (
 					<div class="relative">
-						<span class="absolute -left-[1.65rem] top-1 h-2.5 w-2.5 rounded-full border border-[#00ffff] bg-[#0a0a0a]" />
-						<p class="font-tech text-[11px] uppercase tracking-[0.18em] text-[#39ff14]">{year}</p>
+						<span class="absolute -left-[1.65rem] top-1 h-2.5 w-2.5 rounded-full border border-primary bg-[#0a0a0a]" />
+						<p class="font-tech text-[11px] uppercase tracking-[0.18em] text-accent">{year}</p>
 						<p class="mt-1 text-sm leading-relaxed text-slate-300/85">{event}</p>
 					</div>
 				))}

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -39,7 +39,7 @@ const { page } = Astro.props as { page: Page<CollectionEntry<'posts'>> };
 const prevUrl = page.url.prev ?? null;
 const nextUrl = page.url.next ?? null;
 
-const postIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a4 4 0 0 1-4 4z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><line x1="10" x2="16" y1="13" y2="13"/><line x1="10" x2="14" y1="17" y2="17"/></svg>`;
+const postIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a4 4 0 0 1-4 4z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><line x1="10" x2="16" y1="13" y2="13"/><line x1="10" x2="14" y1="17" y2="17"/></svg>`;
 const arrowSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>`;
 const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>`;
 ---
@@ -75,7 +75,7 @@ const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11"
 
 						<!-- Top row: icon + title -->
 						<div class="flex items-start gap-2.5">
-							<span set:html={postIcon} class="shrink-0 opacity-70 mt-0.5" />
+							<span set:html={postIcon} class="shrink-0 text-accent opacity-70 mt-0.5" />
 							<h2 class="font-orbitron text-sm uppercase tracking-[0.1em] text-cyan-100 leading-tight">{entry.data.title}</h2>
 						</div>
 
@@ -105,7 +105,7 @@ const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11"
 						<div class="mt-auto pt-1">
 							<a
 								href={`/blog/${entry.id}`}
-								class="flex items-center gap-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-[#39ff14]/60 hover:text-[#39ff14] transition-colors w-fit"
+								class="flex items-center gap-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-accent/60 hover:text-accent transition-colors w-fit"
 							>
 								Read Post
 								<span set:html={arrowSvg} />

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -55,7 +55,7 @@ const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11"
 
 							<!-- Top row: icon + title -->
 							<div class="flex items-start gap-2.5">
-								<span set:html={postIcon} class="shrink-0 opacity-70 mt-0.5" />
+								<span set:html={postIcon} class="shrink-0 text-accent opacity-70 mt-0.5" />
 								<h2 class="font-orbitron text-sm uppercase tracking-[0.1em] text-cyan-100 leading-tight">{entry.data.title}</h2>
 							</div>
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -12,7 +12,7 @@ const sorted = allPosts.sort((a, b) => b.data.date.valueOf() - a.data.date.value
 const pagePosts = sorted.slice(0, PAGE_SIZE);
 const totalPages = Math.ceil(sorted.length / PAGE_SIZE);
 
-const postIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a4 4 0 0 1-4 4z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><line x1="10" x2="16" y1="13" y2="13"/><line x1="10" x2="14" y1="17" y2="17"/></svg>`;
+const postIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a4 4 0 0 1-4 4z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><line x1="10" x2="16" y1="13" y2="13"/><line x1="10" x2="14" y1="17" y2="17"/></svg>`;
 const arrowSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>`;
 const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>`;
 ---
@@ -37,7 +37,7 @@ const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11"
 		<!-- Post cards -->
 		{sorted.length === 0 ? (
 			<div class="blueprint-border rounded-md bg-black/35 p-12 text-center">
-				<div class="mb-4 flex justify-center opacity-30" set:html={postIcon} />
+				<div class="mb-4 flex justify-center opacity-30 text-accent" set:html={postIcon} />
 				<p class="font-orbitron text-sm uppercase tracking-[0.16em] text-cyan-300/50">No posts yet</p>
 				<p class="mt-2 font-tech text-[11px] text-slate-400/60">Posts will appear here once added to the collection.</p>
 			</div>
@@ -85,7 +85,7 @@ const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11"
 							<div class="mt-auto pt-1">
 								<a
 									href={`/blog/${entry.id}`}
-									class="flex items-center gap-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-[#39ff14]/60 hover:text-[#39ff14] transition-colors w-fit"
+									class="flex items-center gap-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-accent/60 hover:text-accent transition-colors w-fit"
 								>
 									Read Post
 									<span set:html={arrowSvg} />

--- a/src/pages/kitchen.astro
+++ b/src/pages/kitchen.astro
@@ -10,15 +10,15 @@ const categories = ['all', 'baking', 'cooking', 'preservation'] as const;
 
 const categoryConfig: Record<string, { label: string; color: string }> = {
 	baking:       { label: 'Baking',       color: 'text-amber-400/80 border-amber-400/30 bg-amber-400/5' },
-	cooking:      { label: 'Cooking',      color: 'text-[#39ff14]/80 border-[#39ff14]/30 bg-[#39ff14]/5' },
-	preservation: { label: 'Preservation', color: 'text-[#00ffff]/80 border-[#00ffff]/30 bg-[#00ffff]/5' },
+	cooking:      { label: 'Cooking',      color: 'text-accent/80 border-accent/30 bg-accent/5' },
+	preservation: { label: 'Preservation', color: 'text-primary/80 border-primary/30 bg-primary/5' },
 };
 
 // Inline SVGs
-const utensilsSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2"/><path d="M7 2v20"/><path d="M21 15V2a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3Zm0 0v7"/></svg>`;
+const utensilsSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2"/><path d="M7 2v20"/><path d="M21 15V2a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3Zm0 0v7"/></svg>`;
 const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>`;
 const arrowSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>`;
-const zapSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>`;
+const zapSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>`;
 ---
 
 <Layout
@@ -74,7 +74,7 @@ const zapSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" v
 		<!-- Recipe cards -->
 		{sorted.length === 0 ? (
 			<div class="blueprint-border rounded-md bg-black/35 p-12 text-center">
-				<div class="mb-4 flex justify-center opacity-30" set:html={utensilsSvg} />
+				<div class="mb-4 flex justify-center opacity-30 text-accent" set:html={utensilsSvg} />
 				<p class="font-orbitron text-sm uppercase tracking-[0.16em] text-cyan-300/50">No recipes yet</p>
 				<p class="mt-2 font-tech text-[11px] text-slate-400/60">Recipes will appear here once added to the collection.</p>
 			</div>
@@ -90,7 +90,7 @@ const zapSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" v
 						>
 							<!-- Top row: icon + title -->
 							<div class="flex items-start gap-2.5">
-								<span set:html={utensilsSvg} class="shrink-0 opacity-70 mt-0.5" />
+								<span set:html={utensilsSvg} class="shrink-0 text-accent opacity-70 mt-0.5" />
 								<h2 class="font-orbitron text-sm uppercase tracking-[0.1em] text-cyan-100 leading-tight">{entry.data.title}</h2>
 							</div>
 
@@ -128,7 +128,7 @@ const zapSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" v
 							<div class="mt-auto pt-1">
 								<a
 									href={`/kitchen/${slug}`}
-									class="flex items-center gap-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-[#39ff14]/60 hover:text-[#39ff14] transition-colors w-fit"
+									class="flex items-center gap-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-accent/60 hover:text-accent transition-colors w-fit"
 								>
 									View Recipe
 									<span set:html={arrowSvg} />

--- a/src/pages/kitchen/[slug].astro
+++ b/src/pages/kitchen/[slug].astro
@@ -37,8 +37,8 @@ if (entry.data.image) {
 
 const categoryConfig: Record<string, { label: string; color: string }> = {
 	baking:       { label: 'Baking',       color: 'text-amber-400/80 border-amber-400/30 bg-amber-400/5' },
-	cooking:      { label: 'Cooking',      color: 'text-[#39ff14]/80 border-[#39ff14]/30 bg-[#39ff14]/5' },
-	preservation: { label: 'Preservation', color: 'text-[#00ffff]/80 border-[#00ffff]/30 bg-[#00ffff]/5' },
+	cooking:      { label: 'Cooking',      color: 'text-accent/80 border-accent/30 bg-accent/5' },
+	preservation: { label: 'Preservation', color: 'text-primary/80 border-primary/30 bg-primary/5' },
 };
 
 const cat = categoryConfig[entry.data.category];

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -33,15 +33,15 @@ const galleryItems: BlueprintImage[] = await buildGalleryItems(entry.data.images
 const stepItems: StepItem[] = await buildStepItems(entry.data.steps);
 
 const statusConfig: Record<string, { label: string; classes: string }> = {
-	active:   { label: 'ACTIVE',   classes: 'border-[#39ff14]/40 text-[#39ff14]/80 bg-[#39ff14]/5' },
-	wip:      { label: 'WIP',      classes: 'border-[#00ffff]/40 text-[#00ffff]/80 bg-[#00ffff]/5' },
+	active:   { label: 'ACTIVE',   classes: 'border-accent/40 text-accent/80 bg-accent/5' },
+	wip:      { label: 'WIP',      classes: 'border-primary/40 text-primary/80 bg-primary/5' },
 	complete: { label: 'COMPLETE', classes: 'border-white/25 text-white/60 bg-white/5' },
 	archived: { label: 'ARCHIVED', classes: 'border-slate-500/30 text-slate-500/60 bg-slate-500/5' },
 };
 
 const categoryConfig: Record<string, { label: string; color: string }> = {
-	tech:   { label: 'Tech',   color: 'text-[#00ffff]/80 border-[#00ffff]/30 bg-[#00ffff]/5' },
-	home:   { label: 'Home',   color: 'text-[#39ff14]/80 border-[#39ff14]/30 bg-[#39ff14]/5' },
+	tech:   { label: 'Tech',   color: 'text-primary/80 border-primary/30 bg-primary/5' },
+	home:   { label: 'Home',   color: 'text-accent/80 border-accent/30 bg-accent/5' },
 	garden: { label: 'Garden', color: 'text-amber-400/80 border-amber-400/30 bg-amber-400/5' },
 };
 

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -2,12 +2,12 @@
 import Layout from '../layouts/Layout.astro';
 import { skills, experience, previousRoles, certs } from '../data/resume';
 
-const zapSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>`;
-const awardSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="6"/><path d="M15.477 12.89 17 22l-5-3-5 3 1.523-9.11"/></svg>`;
-const cpuSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#00ffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><path d="M15 2v2"/><path d="M15 20v2"/><path d="M2 15h2"/><path d="M2 9h2"/><path d="M20 15h2"/><path d="M20 9h2"/><path d="M9 2v2"/><path d="M9 20v2"/></svg>`;
-const capSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#00ffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0z"/><path d="M22 10v6"/><path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5"/></svg>`;
-const briefcaseSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#00ffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="14" x="2" y="7" rx="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/></svg>`;
-const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#00ffff" stroke-opacity="0.5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>`;
+const zapSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>`;
+const awardSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="6"/><path d="M15.477 12.89 17 22l-5-3-5 3 1.523-9.11"/></svg>`;
+const cpuSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><path d="M15 2v2"/><path d="M15 20v2"/><path d="M2 15h2"/><path d="M2 9h2"/><path d="M20 15h2"/><path d="M20 9h2"/><path d="M9 2v2"/><path d="M9 20v2"/></svg>`;
+const capSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0z"/><path d="M22 10v6"/><path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5"/></svg>`;
+const briefcaseSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="14" x="2" y="7" rx="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/></svg>`;
+const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-opacity="0.5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>`;
 ---
 
 <Layout
@@ -29,7 +29,7 @@ const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13"
 				onclick="window.print()"
 				class="mt-5 flex items-center gap-2 rounded blueprint-border px-4 py-2 font-tech text-[11px] uppercase tracking-[0.16em] text-cyan-300/80 hover:text-cyan-100 transition-colors print:hidden"
 			>
-				<span set:html={zapSvg} aria-hidden="true" />
+				<span set:html={zapSvg} aria-hidden="true" class="text-accent" />
 				Print / Save PDF
 			</button>
 		</header>
@@ -42,13 +42,13 @@ const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13"
 				<!-- Certifications & Education -->
 				<section aria-labelledby="certs-heading" class="blueprint-border rounded-md bg-black/35 p-5 print:border print:border-gray-300 print:bg-white">
 					<h2 id="certs-heading" class="font-orbitron mb-4 text-xs uppercase tracking-[0.2em] text-cyan-300/70 flex items-center gap-2 print:text-gray-700">
-						<span set:html={awardSvg} />
+						<span set:html={awardSvg} class="text-accent" />
 						Certifications & Education
 					</h2>
 					<ul class="space-y-3" role="list">
 						{certs.map(({ name, issuer, year, highlight }) => (
-							<li class={`rounded p-3 ${ highlight ? 'neon-border bg-[#39ff14]/5' : 'blueprint-border bg-black/20 print:border-gray-200' }`}>
-								<p class={`font-tech text-[11px] uppercase tracking-[0.14em] ${ highlight ? 'text-[#39ff14]' : 'text-cyan-300/70 print:text-gray-500' }`}>
+							<li class={`rounded p-3 ${ highlight ? 'neon-border bg-accent/5' : 'blueprint-border bg-black/20 print:border-gray-200' }`}>
+								<p class={`font-tech text-[11px] uppercase tracking-[0.14em] ${ highlight ? 'text-accent' : 'text-cyan-300/70 print:text-gray-500' }`}>
 									{issuer} &middot; {year}
 								</p>
 								<p class="mt-1 text-sm text-slate-200/90 print:text-gray-800">{name}</p>
@@ -60,13 +60,13 @@ const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13"
 				<!-- Skills -->
 				<section aria-labelledby="skills-heading" class="blueprint-border rounded-md bg-black/35 p-5 print:border print:border-gray-300 print:bg-white">
 					<h2 id="skills-heading" class="font-orbitron mb-4 text-xs uppercase tracking-[0.2em] text-cyan-300/70 flex items-center gap-2 print:text-gray-700">
-						<span set:html={cpuSvg} />
+						<span set:html={cpuSvg} class="text-primary" />
 						Skills
 					</h2>
 					<div class="space-y-4">
 						{Object.entries(skills).map(([category, items]) => (
 							<div>
-								<p class="font-tech text-[10px] uppercase tracking-[0.2em] text-[#00ffff]/60 mb-2 print:text-gray-500">{category}</p>
+								<p class="font-tech text-[10px] uppercase tracking-[0.2em] text-primary/60 mb-2 print:text-gray-500">{category}</p>
 								<ul class="space-y-1" role="list">
 									{items.map((item) => (
 										<li class="font-tech text-[11px] text-slate-300/80 before:content-['▸_'] before:text-cyan-300/40 print:text-gray-700">{item}</li>
@@ -84,7 +84,7 @@ const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13"
 
 				<section aria-labelledby="exp-heading">
 					<h2 id="exp-heading" class="font-orbitron mb-5 text-xs uppercase tracking-[0.2em] text-cyan-300/70 flex items-center gap-2 print:text-gray-700">
-						<span set:html={briefcaseSvg} />
+						<span set:html={briefcaseSvg} class="text-primary" />
 						Experience
 					</h2>
 					<div class="space-y-5">
@@ -94,11 +94,11 @@ const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13"
 									<h3 class="font-orbitron text-sm uppercase tracking-[0.1em] text-cyan-100 print:text-black">{title}</h3>
 									<span class="font-tech text-[11px] uppercase tracking-[0.14em] text-cyan-300/50 print:text-gray-400">{period}</span>
 							</div>
-								<p class="font-tech text-[10px] uppercase tracking-[0.18em] text-[#39ff14]/70 mb-3 print:text-gray-500">{org}</p>
+								<p class="font-tech text-[10px] uppercase tracking-[0.18em] text-accent/70 mb-3 print:text-gray-500">{org}</p>
 								<ul class="space-y-2" role="list">
 									{bullets.map((b) => (
 										<li class="flex gap-2 text-sm leading-relaxed text-slate-300/80 print:text-gray-700">
-											<span class="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-[#00ffff]/40 print:bg-gray-400" aria-hidden="true" />
+											<span class="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-primary/40 print:bg-gray-400" aria-hidden="true" />
 											{b}
 										</li>
 									))}
@@ -111,13 +111,13 @@ const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13"
 				<!-- Previous Roles -->
 				<section aria-labelledby="prev-heading">
 					<h2 id="prev-heading" class="font-orbitron mb-4 text-xs uppercase tracking-[0.2em] text-cyan-300/70 flex items-center gap-2 print:text-gray-700">
-						<span set:html={clockSvg} />
+						<span set:html={clockSvg} class="text-primary/50" />
 						Previous Experience
 					</h2>
 					<div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
 						{previousRoles.map(({ title, org, period, location }) => (
 							<div class="blueprint-border rounded-md bg-black/20 p-4 print:border print:border-gray-200 print:bg-white">
-								<p class="font-tech text-[10px] uppercase tracking-[0.18em] text-[#39ff14]/60 print:text-gray-400">{org} &middot; {period}</p>
+								<p class="font-tech text-[10px] uppercase tracking-[0.18em] text-accent/60 print:text-gray-400">{org} &middot; {period}</p>
 								<p class="mt-1 text-sm text-slate-300/80 print:text-gray-700">{title}</p>
 								<p class="font-tech text-[10px] uppercase tracking-[0.14em] text-cyan-300/40 mt-1 print:text-gray-400">{location}</p>
 							</div>

--- a/src/pages/writing/[universe]/index.astro
+++ b/src/pages/writing/[universe]/index.astro
@@ -99,7 +99,7 @@ const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11"
 			<h1 class="font-orbitron mt-2 text-2xl uppercase tracking-[0.12em] text-cyan-100 md:text-4xl">
 				{universe.data.name}
 			</h1>
-			<p class="mt-2 font-tech text-sm italic text-[#39ff14]/70">{universe.data.tagline}</p>
+			<p class="mt-2 font-tech text-sm italic text-accent/70">{universe.data.tagline}</p>
 			<p class="mt-4 max-w-2xl text-base leading-relaxed text-slate-300/85">
 				{universe.data.description}
 			</p>
@@ -167,7 +167,7 @@ const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11"
 					</p>
 					<a
 						href={`/writing/novels/${featuredNovel.id}`}
-						class="inline-flex items-center gap-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-[#39ff14]/60 hover:text-[#39ff14] transition-colors"
+						class="inline-flex items-center gap-1.5 font-tech text-[11px] uppercase tracking-[0.16em] text-accent/60 hover:text-accent transition-colors"
 					>
 						Read Excerpt <span set:html={arrowSvg} />
 					</a>

--- a/src/pages/writing/[universe]/timeline.astro
+++ b/src/pages/writing/[universe]/timeline.astro
@@ -82,11 +82,11 @@ for (const [era, events] of eras.entries()) {
 							<div class="mb-6 flex items-center gap-4">
 								<h2
 									id={`era-${era.replace(/\s+/g, '-').toLowerCase()}`}
-									class="font-orbitron text-sm uppercase tracking-[0.18em] text-[#39ff14]/70"
+									class="font-orbitron text-sm uppercase tracking-[0.18em] text-accent/70"
 								>
 									{era}
 								</h2>
-								<div class="flex-1 h-px bg-[#39ff14]/15" aria-hidden="true"></div>
+								<div class="flex-1 h-px bg-accent/15" aria-hidden="true"></div>
 							</div>
 						)}
 
@@ -94,7 +94,7 @@ for (const [era, events] of eras.entries()) {
 						<div class="relative">
 							<!-- Rail line -->
 							<div
-								class="absolute left-[5px] top-2 bottom-2 w-px bg-[#39ff14]/20"
+								class="absolute left-[5px] top-2 bottom-2 w-px bg-accent/20"
 								aria-hidden="true"
 							></div>
 

--- a/src/pages/writing/characters/[slug].astro
+++ b/src/pages/writing/characters/[slug].astro
@@ -97,7 +97,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? 'https://sybilsed
 			)}
 
 			{entry.data.highlight && (
-				<p class="mt-4 font-tech text-sm italic leading-relaxed text-slate-400/70 border-l-2 border-[#39ff14]/25 pl-4">
+				<p class="mt-4 font-tech text-sm italic leading-relaxed text-slate-400/70 border-l-2 border-accent/25 pl-4">
 					{entry.data.highlight}
 				</p>
 			)}

--- a/src/pages/writing/characters/index.astro
+++ b/src/pages/writing/characters/index.astro
@@ -18,7 +18,7 @@ const allCharacters = characters.sort((a, b) => {
 // Build list of unique universes for client-side filtering
 const universes = [...new Set(allCharacters.map((c) => c.data.universe))].sort();
 
-const personSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><circle cx="12" cy="8" r="5"/><path d="M20 21a8 8 0 1 0-16 0"/></svg>`;
+const personSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><circle cx="12" cy="8" r="5"/><path d="M20 21a8 8 0 1 0-16 0"/></svg>`;
 ---
 
 <Layout
@@ -65,7 +65,7 @@ const personSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18
 
 		{allCharacters.length === 0 ? (
 			<div class="blueprint-border rounded-md bg-black/35 p-12 text-center">
-				<div class="mb-4 flex justify-center opacity-30" set:html={personSvg} />
+				<div class="mb-4 flex justify-center opacity-30 text-accent" set:html={personSvg} />
 				<p class="font-orbitron text-sm uppercase tracking-[0.16em] text-cyan-300/50">No characters yet</p>
 				<p class="mt-2 font-tech text-[11px] text-slate-400/60">
 					Character entries will appear here once added to the collection.

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -12,7 +12,7 @@ const sorted = allUniverses.sort((a, b) => {
 	return order[a.data.status] - order[b.data.status];
 });
 
-const globeSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/></svg>`;
+const globeSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/></svg>`;
 ---
 
 <Layout

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -67,7 +67,7 @@ const globeSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18"
 			sorted.length === 0 ? (
 				<div class="blueprint-border rounded-md bg-black/35 p-12 text-center">
 					<div
-						class="mb-4 flex justify-center opacity-30"
+						class="mb-4 flex justify-center opacity-30 text-accent"
 						set:html={globeSvg}
 					/>
 					<p class="font-orbitron text-sm uppercase tracking-[0.16em] text-cyan-300/50">

--- a/src/pages/writing/lore/[slug].astro
+++ b/src/pages/writing/lore/[slug].astro
@@ -125,7 +125,7 @@ const arrowSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11"
 								class="group flex items-center justify-between gap-4 rounded blueprint-border bg-black/40 px-4 py-2.5 transition-colors hover:bg-cyan-300/5"
 							>
 								<span class="font-orbitron text-[11px] uppercase tracking-[0.08em] text-cyan-100 group-hover:text-cyan-300 transition-colors truncate">{story.data.title}</span>
-								<span set:html={arrowSvg} class="shrink-0 text-cyan-300/30 group-hover:text-[#39ff14]/60" />
+								<span set:html={arrowSvg} class="shrink-0 text-cyan-300/30 group-hover:text-accent/60" />
 							</a>
 						</li>
 					))}

--- a/src/pages/writing/lore/index.astro
+++ b/src/pages/writing/lore/index.astro
@@ -22,7 +22,7 @@ const grouped = CATEGORIES.reduce<Record<LoreCategory, typeof sorted>>((acc, cat
 	return acc;
 }, {} as Record<LoreCategory, typeof sorted>);
 
-const bookOpenSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>`;
+const bookOpenSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>`;
 ---
 
 <Layout
@@ -63,7 +63,7 @@ const bookOpenSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="
 
 		{allLore.length === 0 ? (
 			<div class="blueprint-border rounded-md bg-black/35 p-12 text-center">
-				<div class="mb-4 flex justify-center opacity-30" set:html={bookOpenSvg} />
+				<div class="mb-4 flex justify-center opacity-30 text-accent" set:html={bookOpenSvg} />
 				<p class="font-orbitron text-sm uppercase tracking-[0.16em] text-cyan-300/50">No lore entries yet</p>
 				<p class="mt-2 font-tech text-[11px] text-slate-400/60">Lore entries will appear here once added to the collection.</p>
 			</div>

--- a/src/pages/writing/novels/[slug].astro
+++ b/src/pages/writing/novels/[slug].astro
@@ -107,7 +107,7 @@ const clockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11"
 		{entry.body && (
 			<section class="mb-8 blueprint-border rounded-md bg-black/35 p-6 md:p-8">
 				<p class="font-tech text-[10px] uppercase tracking-[0.22em] text-cyan-300/50 mb-6">// Excerpt</p>
-				<div class="prose-novel border-l-2 border-[#39ff14]/20 pl-6">
+				<div class="prose-novel border-l-2 border-accent/20 pl-6">
 					<Content />
 				</div>
 			</section>

--- a/src/pages/writing/novels/index.astro
+++ b/src/pages/writing/novels/index.astro
@@ -20,7 +20,7 @@ const sorted = allNovels.sort((a, b) => {
 
 const universes = [...new Set(allNovels.map((n) => n.data.universe))].sort();
 
-const bookSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/></svg>`;
+const bookSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/></svg>`;
 ---
 
 <Layout
@@ -60,7 +60,7 @@ const bookSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" 
 
 		{sorted.length === 0 ? (
 			<div class="blueprint-border rounded-md bg-black/35 p-12 text-center">
-				<div class="mb-4 flex justify-center opacity-30" set:html={bookSvg} />
+				<div class="mb-4 flex justify-center opacity-30 text-accent" set:html={bookSvg} />
 				<p class="font-orbitron text-sm uppercase tracking-[0.16em] text-cyan-300/50">No novels yet</p>
 				<p class="mt-2 font-tech text-[11px] text-slate-400/60">Novel entries will appear here once added to the collection.</p>
 			</div>

--- a/src/pages/writing/stories/index.astro
+++ b/src/pages/writing/stories/index.astro
@@ -19,7 +19,7 @@ const sorted = allStories.sort((a, b) => {
 const universes = [...new Set(allStories.map((s) => s.data.universe))].sort();
 const allTags   = [...new Set(allStories.flatMap((s) => s.data.tags))].sort();
 
-const penSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#39ff14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>`;
+const penSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>`;
 ---
 
 <Layout
@@ -70,7 +70,7 @@ const penSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" v
 
 		{sorted.length === 0 ? (
 			<div class="blueprint-border rounded-md bg-black/35 p-12 text-center">
-				<div class="mb-4 flex justify-center opacity-30" set:html={penSvg} />
+				<div class="mb-4 flex justify-center opacity-30 text-accent" set:html={penSvg} />
 				<p class="font-orbitron text-sm uppercase tracking-[0.16em] text-cyan-300/50">No stories yet</p>
 				<p class="mt-2 font-tech text-[11px] text-slate-400/60">Short story entries will appear here once added to the collection.</p>
 			</div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,6 +1,15 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500;700&family=Lora:ital,wght@0,400;0,500;1,400;1,500&family=Orbitron:wght@500;700;800&display=swap");
 @import "tailwindcss";
 
+/* ── Semantic colour tokens ──────────────────────────────────
+   @theme inline keeps the var() references live so that overriding
+   --neon-green / --blueprint-cyan in [data-theme="light"] automatically
+   cascades into text-accent/*, bg-accent/*, border-primary/*, etc.    */
+@theme inline {
+  --color-accent:  var(--neon-green);      /* text-accent, bg-accent, border-accent */
+  --color-primary: var(--blueprint-cyan);  /* text-primary, bg-primary, border-primary */
+}
+
 :root {
   /* Surfaces */
   --bg-charcoal: #0a0a0a;
@@ -79,13 +88,13 @@ body {
 
 /* Neon green variant for active/highlight states */
 .neon-border {
-  border: 1px solid rgba(57, 255, 20, 0.4);
+  border: 1px solid color-mix(in srgb, var(--neon-green) 40%, transparent);
   box-shadow: var(--neon-green-glow);
 }
 
 /* Cyan glow shadow — use on images or cards that need a soft cyan halo */
 .glow-cyan {
-  box-shadow: 0 0 15px rgba(0, 255, 255, 0.3);
+  box-shadow: 0 0 15px color-mix(in srgb, var(--blueprint-cyan) 30%, transparent);
 }
 
 /* Focus styles */
@@ -119,9 +128,10 @@ body {
   --blueprint-border: rgba(29, 78, 216, 0.35);
   --blueprint-glow: 0 0 24px rgba(29, 78, 216, 0.12);
 
-  /* Sky-600: secondary accent for active/highlight states */
-  --accent-secondary: #0284c7;
-  --accent-secondary-glow: 0 0 16px rgba(2, 132, 199, 0.2);
+  /* Blue-700: neon-green maps to blueprint blue in light mode,
+     so text-accent/bg-accent/border-accent all resolve correctly. */
+  --neon-green: #1d4ed8;
+  --neon-green-glow: 0 0 16px rgba(29, 78, 216, 0.2);
 }
 
 [data-theme="light"] body {
@@ -135,15 +145,9 @@ body {
     linear-gradient(90deg, rgba(29, 78, 216, 0.07) 1px, transparent 1px);
 }
 
-/* Neon border uses a hardcoded rgba — override to match updated --neon-green */
-[data-theme="light"] .neon-border {
-  border-color: rgba(2, 132, 199, 0.4);
-}
-
-/* Cyan glow override */
-[data-theme="light"] .glow-cyan {
-  box-shadow: 0 0 15px rgba(29, 78, 216, 0.3);
-}
+/* .neon-border and .glow-cyan now use CSS variables — no overrides needed.
+   The [data-theme="light"] block above remaps --neon-green and --blueprint-cyan
+   so both utilities cascade automatically. */
 
 /* Nav intentionally stays dark in light mode — no overrides needed.
    Cards use hardcoded black/alpha — remap to blue-tinted ice surfaces. */
@@ -194,15 +198,12 @@ body {
 [data-theme="light"] nav .text-cyan-300\/60 { color: rgba(103, 232, 249, 0.6); }
 [data-theme="light"] nav .text-cyan-300\/70 { color: rgba(103, 232, 249, 0.7); }
 [data-theme="light"] nav .text-cyan-300\/80 { color: rgba(103, 232, 249, 0.8); }
-/* neon-border active state — keep original green glow in nav */
-[data-theme="light"] nav .neon-border { border-color: rgba(57, 255, 20, 0.4); box-shadow: 0 0 16px rgba(57, 255, 20, 0.25); }
+/* Nav stays dark — restore neon-green variable so text-accent and neon-border
+   both resolve correctly against the dark nav background in all themes. */
+[data-theme="light"] nav {
+  --neon-green: #39ff14;
+  --neon-green-glow: 0 0 16px rgba(57, 255, 20, 0.25);
+}
 
-/* ── Hardcoded hex colour overrides (resume.astro uses text-[#hex]/opacity) ─
-   These bypass Tailwind's semantic classes so must be overridden explicitly. */
-/* Neon green → blue-700 equivalent */
-[data-theme="light"] .text-\[\#39ff14\]\/70 { color: rgba(29, 78, 216, 0.82); }
-[data-theme="light"] .text-\[\#39ff14\]\/60 { color: rgba(29, 78, 216, 0.75); }
-/* Neon cyan → blue-700 equivalent */
-[data-theme="light"] .text-\[\#00ffff\]\/60 { color: rgba(29, 78, 216, 0.75); }
-/* Bullet dot background */
-[data-theme="light"] .bg-\[\#00ffff\]\/40  { background-color: rgba(29, 78, 216, 0.25); }
+/* Hex-escape overrides removed — components now use text-accent / text-primary
+   which cascade through the CSS variable system automatically. */


### PR DESCRIPTION
This pull request updates the site's color system by replacing hardcoded neon green (`#39ff14`) and cyan (`#00ffff`) color values with semantic CSS variables (`accent`, `primary`). This change improves maintainability and theming flexibility across navigation, badges, cards, and writing-related components. Additionally, it introduces a customizable icon color for `TechCard` components.

**Color system refactor:**

* Replaced all instances of hardcoded neon green and cyan colors in navigation elements, badges, and UI highlights with `accent` and `primary` CSS variables in `src/components/Nav.astro`, `src/components/writing/CategoryBadge.astro`, `src/components/writing/StatusBadge.astro`, and related files. [[1]](diffhunk://#diff-6a11449ae744e40665df9d1ad66ee5b58e6e4a00f656614e90ae630c974943baL81-R81) [[2]](diffhunk://#diff-6a11449ae744e40665df9d1ad66ee5b58e6e4a00f656614e90ae630c974943baL100-R100) [[3]](diffhunk://#diff-6a11449ae744e40665df9d1ad66ee5b58e6e4a00f656614e90ae630c974943baL127-R127) [[4]](diffhunk://#diff-6a11449ae744e40665df9d1ad66ee5b58e6e4a00f656614e90ae630c974943baL149-R149) [[5]](diffhunk://#diff-6a11449ae744e40665df9d1ad66ee5b58e6e4a00f656614e90ae630c974943baL190-R190) [[6]](diffhunk://#diff-6a11449ae744e40665df9d1ad66ee5b58e6e4a00f656614e90ae630c974943baL206-R206) [[7]](diffhunk://#diff-6a11449ae744e40665df9d1ad66ee5b58e6e4a00f656614e90ae630c974943baL222-R222) [[8]](diffhunk://#diff-6a11449ae744e40665df9d1ad66ee5b58e6e4a00f656614e90ae630c974943baL240-R240) [[9]](diffhunk://#diff-e0abcd19b60c4eac90804d22f81466ebec53ec121ece635c4dd35ec86d4b7325L15-R15) [[10]](diffhunk://#diff-bbe9e558d38481a1e6e5a0de508e91a0a7e4cd9cde9f45c467c32f610eb3f90aL32-R32) [[11]](diffhunk://#diff-e7c7532dd919306d88542f4c63cf5e9933f009743620e6d3ded02eb0a148b34dL28-R28) [[12]](diffhunk://#diff-e7c7532dd919306d88542f4c63cf5e9933f009743620e6d3ded02eb0a148b34dL59-R59) [[13]](diffhunk://#diff-e822ad5370dc259773d633c54853011caf3e4d5f6fc1fc7dca2b3a5e08b16762L17-R18) [[14]](diffhunk://#diff-e822ad5370dc259773d633c54853011caf3e4d5f6fc1fc7dca2b3a5e08b16762L32-R32) [[15]](diffhunk://#diff-e822ad5370dc259773d633c54853011caf3e4d5f6fc1fc7dca2b3a5e08b16762L49-R49) [[16]](diffhunk://#diff-db24bba2b8c2a225abc84677bc6a20af3ede827e8a6af401c9d86264ae14dfefL19-R20) [[17]](diffhunk://#diff-717f67d92e22b866e0f0a399b1090283370f3f15c72bbdd5a365ad3fa48ec37bL25-R25) [[18]](diffhunk://#diff-717f67d92e22b866e0f0a399b1090283370f3f15c72bbdd5a365ad3fa48ec37bL57-R57) [[19]](diffhunk://#diff-5137852a7626904ddc94572a461c4549282fa27f803b0b44ff2daee27a2e81eeL34-R34) [[20]](diffhunk://#diff-5137852a7626904ddc94572a461c4549282fa27f803b0b44ff2daee27a2e81eeL49-R49) [[21]](diffhunk://#diff-cf5df9264cc42995e4ab7508909cf46becbbba01f96c0b896bb80dc42e6f1a0fL20-R20) [[22]](diffhunk://#diff-cf5df9264cc42995e4ab7508909cf46becbbba01f96c0b896bb80dc42e6f1a0fL33-R33) [[23]](diffhunk://#diff-cf5df9264cc42995e4ab7508909cf46becbbba01f96c0b896bb80dc42e6f1a0fL43-R51)

**Component-specific improvements:**

* Updated the `StepGallery` badge to use the `accent` color variable for the step number, ensuring consistency with the new color system.
* Added an `iconClass` prop to `TechCard.astro` for customizable icon coloring, defaulting to `text-cyan-300`. [[1]](diffhunk://#diff-babcdac9f93ed0b3eedb4c72ccd7c16f1661261e3c5208ead298679df6babfc1R22) [[2]](diffhunk://#diff-babcdac9f93ed0b3eedb4c72ccd7c16f1661261e3c5208ead298679df6babfc1R34) [[3]](diffhunk://#diff-babcdac9f93ed0b3eedb4c72ccd7c16f1661261e3c5208ead298679df6babfc1L58-R60)

These changes modernize the site's color handling, making it easier to update the theme and maintain a consistent visual style.