### PR TITLE
Keep screen awake on recipe pages (Wake Lock API)

### DIFF
--- a/src/pages/kitchen/[slug].astro
+++ b/src/pages/kitchen/[slug].astro
@@ -256,27 +256,28 @@ const utensilsSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="
 	</style>
 
 	<script is:inline>
-		// Screen Wake Lock API to keep the screen on while cooking.
-		// Silent graceful no-op if unsupported.
-		let wakeLock = null;
-
-		async function requestWakeLock() {
-			try {
-				wakeLock = await navigator.wakeLock.request('screen');
-			} catch (err) {
-				// Silently fail if the request is denied or unsupported
-			}
-		}
-
-		if ('wakeLock' in navigator) {
-			requestWakeLock();
-
-			// Re-acquire the lock when the tab becomes visible again.
-			document.addEventListener('visibilitychange', () => {
-				if (wakeLock !== null && document.visibilityState === 'visible') {
-					requestWakeLock();
+		(function() {
+			// Screen Wake Lock API to keep the screen on while cooking.
+			// Silent graceful no-op if unsupported.
+			async function requestWakeLock() {
+				if (document.visibilityState !== 'visible') return;
+				try {
+					await navigator.wakeLock.request('screen');
+				} catch (err) {
+					// Silently fail if the request is denied or unsupported
 				}
-			});
-		}
+			}
+
+			if ('wakeLock' in navigator) {
+				requestWakeLock();
+
+				// Re-acquire the lock when the tab becomes visible again.
+				document.addEventListener('visibilitychange', () => {
+					if (document.visibilityState === 'visible') {
+						requestWakeLock();
+					}
+				});
+			}
+		})();
 	</script>
 </Layout>

--- a/src/pages/kitchen/[slug].astro
+++ b/src/pages/kitchen/[slug].astro
@@ -254,4 +254,29 @@ const utensilsSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="
 			color: rgb(15 23 42 / 0.65);
 		}
 	</style>
+
+	<script is:inline>
+		// Screen Wake Lock API to keep the screen on while cooking.
+		// Silent graceful no-op if unsupported.
+		let wakeLock = null;
+
+		async function requestWakeLock() {
+			try {
+				wakeLock = await navigator.wakeLock.request('screen');
+			} catch (err) {
+				// Silently fail if the request is denied or unsupported
+			}
+		}
+
+		if ('wakeLock' in navigator) {
+			requestWakeLock();
+
+			// Re-acquire the lock when the tab becomes visible again.
+			document.addEventListener('visibilitychange', () => {
+				if (wakeLock !== null && document.visibilityState === 'visible') {
+					requestWakeLock();
+				}
+			});
+		}
+	</script>
 </Layout>


### PR DESCRIPTION
Implement the Screen Wake Lock API on recipe detail pages to prevent the screen from sleeping while users are cooking. The implementation is silent, handles tab switching, and gracefully fails in unsupported browsers.

Fixes #162

---
*PR created automatically by Jules for task [7959335302329441914](https://jules.google.com/task/7959335302329441914) started by @ngnetworkpro*