### PR TITLE
feat: add additional repos to commit list

### DIFF
--- a/src/components/StatusFeed.astro
+++ b/src/components/StatusFeed.astro
@@ -3,7 +3,10 @@ import { getCollection } from "astro:content";
 import { env } from "cloudflare:workers";
 
 // ─── CONFIG ────────────────────────────────────────────────────────────────
-const GITHUB_REPOS = ["sybilsedge/sybilsedge"];
+const GITHUB_REPOS = [
+  "sybilsedge/sybilsedge",
+  "ngnetworkpro/net-agent-harness",
+];
 const COMMITS_PER_REPO = 3;
 const COMMIT_CACHE_TTL_SECONDS = 60 * 10;
 


### PR DESCRIPTION
This pull request updates the configuration in the `StatusFeed.astro` component to expand the list of GitHub repositories being tracked. Now, in addition to the existing repository, an additional repository is included.

Configuration updates:

* Expanded the `GITHUB_REPOS` array in `StatusFeed.astro` to include both `sybilsedge/sybilsedge` and `ngnetworkpro/net-agent-harness`, allowing status feed updates from both repositories.