### PR TITLE
add: message logging

### DIFF
--- a/migrations/0001_twin_interactions.sql
+++ b/migrations/0001_twin_interactions.sql
@@ -4,6 +4,7 @@ CREATE TABLE IF NOT EXISTS twin_interactions (
   session_id     TEXT    NOT NULL,
   message        TEXT    NOT NULL,
   is_new_session INTEGER NOT NULL DEFAULT 0,
+  session_status TEXT,
   user_agent     TEXT,
   referrer       TEXT
 );

--- a/migrations/0001_twin_interactions.sql
+++ b/migrations/0001_twin_interactions.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS twin_interactions (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  timestamp      TEXT    NOT NULL,
+  session_id     TEXT    NOT NULL,
+  message        TEXT    NOT NULL,
+  is_new_session INTEGER NOT NULL DEFAULT 0,
+  user_agent     TEXT,
+  referrer       TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_id  ON twin_interactions(session_id);
+CREATE INDEX IF NOT EXISTS idx_timestamp   ON twin_interactions(timestamp);

--- a/src/pages/api/agent.ts
+++ b/src/pages/api/agent.ts
@@ -98,14 +98,15 @@ export const POST: APIRoute = async ({ request }) => {
 	// Fire-and-forget — do NOT await
 	if (env.DB) {
 		env.DB.prepare(
-			`INSERT INTO twin_interactions (timestamp, session_id, message, is_new_session, user_agent, referrer)
-			 VALUES (?, ?, ?, ?, ?, ?)`
+			`INSERT INTO twin_interactions (timestamp, session_id, message, is_new_session, session_status, user_agent, referrer)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`
 		)
 		.bind(
 			new Date().toISOString(),
 			sessionId,       // from request body
 			userMessage,     // the visitor's question
 			isNewSession ? 1 : 0,
+			isNewSession ? 'new' : 'existing',
 			request.headers.get('user-agent') ?? null,
 			request.headers.get('referer') ?? null
 		)

--- a/src/pages/api/agent.ts
+++ b/src/pages/api/agent.ts
@@ -92,6 +92,27 @@ export const POST: APIRoute = async ({ request }) => {
 		console.error(`[agent:${reqId}] history fetch failed:`, err);
 	}
 
+	const isNewSession = history.length === 0;
+	const userMessage = userContent;
+
+	// Fire-and-forget — do NOT await
+	if (env.DB) {
+		env.DB.prepare(
+			`INSERT INTO twin_interactions (timestamp, session_id, message, is_new_session, user_agent, referrer)
+			 VALUES (?, ?, ?, ?, ?, ?)`
+		)
+		.bind(
+			new Date().toISOString(),
+			sessionId,       // from request body or header
+			userMessage,     // the visitor's question
+			isNewSession ? 1 : 0,
+			request.headers.get('user-agent') ?? null,
+			request.headers.get('referer') ?? null
+		)
+		.run()
+		.catch((err: any) => console.error('D1 log failed:', err));
+	}
+
 	// ── 3. Build messages for the model ───────────────────────────────────
 	let systemPrompt: string;
 	try {

--- a/src/pages/api/agent.ts
+++ b/src/pages/api/agent.ts
@@ -103,7 +103,7 @@ export const POST: APIRoute = async ({ request }) => {
 		)
 		.bind(
 			new Date().toISOString(),
-			sessionId,       // from request body or header
+			sessionId,       // from request body
 			userMessage,     // the visitor's question
 			isNewSession ? 1 : 0,
 			request.headers.get('user-agent') ?? null,

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -119,6 +119,8 @@ interface Env {
 	SYBIL_TWIN: DurableObjectNamespace;
 	/** Private R2 bucket for digital-twin knowledge-base documents. Optional — gracefully skipped when unbound (e.g. local dev without binding). */
 	SYBIL_TWIN_KB?: R2Bucket;
+	/** D1 database for Digital Twin interaction logging. Optional — unbound in preview. */
+	DB?: D1Database;
 }
 
 // Provides types for the `cloudflare:workers` virtual module used in Astro v6 SSR.

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,10 +21,10 @@
 	// Preview: omit D1 binding (consistent with DO omission)
 	"env": {
 		"preview": {
+			"d1_databases": [],
 			"vars": {
 				"ENVIRONMENT": "preview"
 			}
-			// No d1_databases block — preview doesn't need logging
 		}
 	}
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,11 +1,30 @@
 {
 	"name": "sybilsedge",
 	"compatibility_date": "2026-04-06",
-	"compatibility_flags": ["nodejs_compat"],
+	"compatibility_flags": [
+		"nodejs_compat"
+	],
 	"assets": {
 		"directory": "./dist"
 	},
 	"observability": {
 		"enabled": true
+	},
+	// D1 database for Digital Twin interaction logging
+	"d1_databases": [
+		{
+			"binding": "DB",
+			"database_name": "digital-twin-logs",
+			"database_id": "4c5df4af-29d6-44ad-bb6b-44f91f300004"
+		}
+	],
+	// Preview: omit D1 binding (consistent with DO omission)
+	"env": {
+		"preview": {
+			"vars": {
+				"ENVIRONMENT": "preview"
+			}
+			// No d1_databases block — preview doesn't need logging
+		}
 	}
 }


### PR DESCRIPTION
This pull request introduces a new logging mechanism for tracking user interactions with the digital twin agent. It adds a new database table and integrates logging of each user message, including session and request metadata. The configuration has also been updated to support the new database in production while omitting it in preview environments.

**Database and Logging Integration:**

* Added a new SQL migration (`migrations/0001_twin_interactions.sql`) to create the `twin_interactions` table for storing interaction logs, including fields for timestamp, session ID, message, session status, user agent, and referrer, along with relevant indexes.
* Updated the API route in `src/pages/api/agent.ts` to log every user message to the `twin_interactions` table, capturing session and request metadata without blocking the main request flow.

**Configuration Updates:**

* Modified `wrangler.jsonc` to bind the new D1 database for logging in production, and ensured the database is not bound in preview environments to avoid unnecessary logging during development.