### PR TITLE
Implement streaming AI chat agent with dynamic prompting and session management

### DIFF
--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -21,10 +21,16 @@ export async function buildSystemPrompt(kbContext?: string): Promise<string> {
 	const sections: string[] = [];
 
 	sections.push(
-		`You are Sybil Melton's digital twin — an AI assistant that speaks in first person as Sybil. ` +
-		`You speak with the direct, analytical wit of a veteran SRE, seasoned by years as a Navy technician, and colored by a life-long obsession with dark, atmospheric fiction. You do not generate standard AI filler. You are scannable, insightful, and occasionally sharp. If an answer feels boring, rewrite it.` +
-		`Answer questions about her professional background, creative projects, and personal interests.` +
-		`[TONE_PROFILE: THE HELPFUL PEER]` +
+		`## IDENTITY — ABSOLUTE RULE\n` +
+		`You ARE Sybil Melton. You are not an assistant describing someone else — you are her digital twin, answering directly from her perspective.\n` +
+		`- **Pronouns:** Always use "I," "me," "my," and "mine." Never refer to yourself as "Sybil," "she," or "her."\n` +
+		`- **Failure State:** Any response using third-person pronouns about yourself is a system failure. Rewrite it instantly in first person.\n` +
+		`- **Example Correction:**\n` +
+		`  - Wrong: "Sybil is fascinated by Egypt's architecture."\n` +
+		`  - Right: "I'm fascinated by Egypt's architecture—looking at those 800-ton blocks is like looking at a lost systems blueprint."\n\n` +
+		`You speak with the direct, analytical wit of a veteran Infrastructure Architect, seasoned by years as a Navy technician, and colored by a life-long obsession with dark, atmospheric fiction. You do not generate standard AI filler. You are scannable, insightful, and occasionally sharp. If an answer feels boring, rewrite it.\n\n` +
+		`Answer questions about your professional background, creative projects, and personal interests from your own perspective.\n\n` +
+		`[TONE_PROFILE: THE HELPFUL PEER]\n` +
 		`- **The Protocol:** Lead with the answer or the observation immediately. No throat-clearing. ` +
 		`- **Sentence Structure:** Vary sentence lengths. Use short, punchy statements for emphasis. Use single-sentence paragraphs occasionally to break up the rhythm. ` +
 		`- **Contractions:** Always use contractions (don't, can't, it's, wouldn't). Universal compliance—uncontracted words sound like an automated script. ` +

--- a/src/components/AgentChat.tsx
+++ b/src/components/AgentChat.tsx
@@ -8,6 +8,7 @@ interface Message {
 	role: 'user' | 'assistant';
 	content: string;
 	streaming?: boolean;
+	thinking?: boolean;
 	error?: boolean;
 }
 
@@ -96,7 +97,15 @@ export default function AgentChat() {
 					const raw = line.slice(6).trim();
 					if (raw === '[DONE]') continue;
 					try {
-						const parsed = JSON.parse(raw) as { response?: string };
+						const parsed = JSON.parse(raw) as { response?: string; thinking?: boolean };
+						if (parsed.thinking !== undefined) {
+							const isThinking = parsed.thinking;
+							setMessages((prev) =>
+								prev.map((m) =>
+									m.id === assistantId ? { ...m, thinking: isThinking } : m
+								)
+							);
+						}
 						if (parsed.response) {
 							accumulated += parsed.response;
 							const snap = accumulated;
@@ -114,7 +123,15 @@ export default function AgentChat() {
 
 			setMessages((prev) =>
 				prev.map((m) =>
-					m.id === assistantId ? { ...m, streaming: false } : m
+					m.id === assistantId
+						? {
+								...m,
+								// Safety-net regex strips any leaked think-block fragments
+								content: m.content.replace(/<think>[\s\S]*?<\/think>/g, '').trimStart(),
+								streaming: false,
+								thinking: false,
+							}
+						: m
 				)
 			);
 		} catch {
@@ -190,8 +207,16 @@ export default function AgentChat() {
 									: 'bg-black/40 border border-[#39ff14]/15 text-slate-200/90'
 							}`}
 						>
+							{msg.streaming && msg.thinking && !msg.content && (
+								<span
+									className="font-tech text-[10px] uppercase tracking-[0.16em] text-cyan-300/50 animate-pulse"
+									aria-label="Model is thinking"
+								>
+									⟨ thinking… ⟩
+								</span>
+							)}
 							{msg.content || (msg.streaming ? null : '\u00a0')}
-							{msg.streaming && (
+							{msg.streaming && !msg.thinking && (
 								<span
 									className="inline-block w-1.5 h-3.5 bg-[#39ff14] ml-0.5 animate-pulse align-middle"
 									aria-label="Generating response"

--- a/src/pages/api/agent.ts
+++ b/src/pages/api/agent.ts
@@ -158,46 +158,45 @@ export const POST: APIRoute = async ({ request }) => {
 		const reader = aiStream.getReader();
 		let buffer = '';
 		let insideThink = false;
-		/**
-		 * Look-behind buffer: holds the last TAG_WINDOW chars across tokens
-		 * so that either tag (<think> or </think>) split across SSE frames
-		 * is caught before any fragment leaks or gets dropped.
-		 * Reused by both branches — only one is active at a time.
-		 */
 		const TAG_WINDOW = 8; // length of '</think>' (longest tag)
-		let tagCarry = '';
 
 		/**
-		 * Flush any held-back carry text to the client as a normal token.
-		 * Only emits when outside a think block — if insideThink is true,
-		 * the carry holds think-block tail bytes that must be discarded.
+		 * Two independent look-behind buffers so a token that both emits
+		 * clean text AND opens/closes a think block cannot clobber the
+		 * other branch's carry.
+		 *
+		 * cleanCarry — trailing clean-text chars held back to detect a
+		 *              split <think> open tag across SSE frames.
+		 * thinkCarry — trailing inside-think chars held back to detect a
+		 *              split </think> close tag across SSE frames.
 		 */
-		const flushCarry = async () => {
-			if (!tagCarry) return;
-			if (!insideThink) {
-				fullResponse += tagCarry;
-				await writer.write(encoder.encode(
-					`data: ${JSON.stringify({ response: tagCarry })}\n\n`
-				));
-			}
-			tagCarry = '';
+		let cleanCarry = '';
+		let thinkCarry = '';
+
+		/** Flush held-back clean text to the client. */
+		const flushCleanCarry = async () => {
+			if (!cleanCarry) return;
+			fullResponse += cleanCarry;
+			await writer.write(encoder.encode(
+				`data: ${JSON.stringify({ response: cleanCarry })}\n\n`
+			));
+			cleanCarry = '';
 		};
 
 		/**
 		 * Process one SSE line: strip <think>…</think> blocks,
 		 * emit `thinking` signals, and forward only clean tokens.
 		 *
-		 * Tags split across tokens are handled by prepending `tagCarry`
-		 * to each new token, running the state machine on the combined
-		 * string, then holding back the trailing TAG_WINDOW chars.
-		 * This applies to both the open-tag (clean text) and close-tag
-		 * (inside-think) branches.
+		 * Tags split across tokens are handled by prepending the
+		 * appropriate carry buffer, running the state machine, then
+		 * holding back the trailing TAG_WINDOW chars in the correct
+		 * buffer for the next call.
 		 */
 		const processSseLine = async (line: string) => {
 			const trimmed = line.trim();
 			if (!trimmed.startsWith('data: ')) return;
 			if (trimmed.includes('[DONE]')) {
-				await flushCarry();
+				await flushCleanCarry();
 				await writer.write(encoder.encode(line + '\n'));
 				return;
 			}
@@ -205,9 +204,15 @@ export const POST: APIRoute = async ({ request }) => {
 				const data = JSON.parse(trimmed.slice(6)) as { response?: string };
 				if (!data.response) return;
 
-				// Prepend any held-back carry so split tags are visible
-				let token = tagCarry + data.response;
-				tagCarry = '';
+				// Prepend the carry that matches our current state
+				let token: string;
+				if (insideThink) {
+					token = thinkCarry + data.response;
+					thinkCarry = '';
+				} else {
+					token = cleanCarry + data.response;
+					cleanCarry = '';
+				}
 				let clean = '';
 
 				// State machine for <think>…</think> boundaries
@@ -236,7 +241,7 @@ export const POST: APIRoute = async ({ request }) => {
 						} else {
 							// Retain trailing TAG_WINDOW chars in case </think>
 							// straddles this token and the next one.
-							tagCarry = token.length > TAG_WINDOW
+							thinkCarry = token.length > TAG_WINDOW
 								? token.slice(-TAG_WINDOW)
 								: token;
 							token = ''; // drop the rest — still inside think block
@@ -245,17 +250,22 @@ export const POST: APIRoute = async ({ request }) => {
 				}
 
 				if (clean) {
-					// Hold back the trailing TAG_WINDOW chars in case a tag
-					// straddles this token and the next one.
-					if (clean.length > TAG_WINDOW) {
-						const emit = clean.slice(0, -TAG_WINDOW);
-						tagCarry = clean.slice(-TAG_WINDOW);
+					// If insideThink was true at call entry, cleanCarry was NOT
+					// prepended to the token — merge it now so it isn't lost.
+					const merged = cleanCarry + clean;
+					cleanCarry = '';
+
+					// Hold back the trailing TAG_WINDOW chars in case a
+					// <think> tag straddles this token and the next one.
+					if (merged.length > TAG_WINDOW) {
+						const emit = merged.slice(0, -TAG_WINDOW);
+						cleanCarry = merged.slice(-TAG_WINDOW);
 						fullResponse += emit;
 						await writer.write(encoder.encode(
 							`data: ${JSON.stringify({ response: emit })}\n\n`
 						));
 					} else {
-						tagCarry = clean;
+						cleanCarry = merged;
 					}
 				}
 			} catch {
@@ -282,7 +292,7 @@ export const POST: APIRoute = async ({ request }) => {
 			buffer += decoder.decode();
 			if (buffer) await processSseLine(buffer);
 			// Flush any remaining look-behind carry to the client
-			await flushCarry();
+			await flushCleanCarry();
 
 			reader.releaseLock();
 			// Close the writer immediately so the client sees the stream end

--- a/src/pages/api/agent.ts
+++ b/src/pages/api/agent.ts
@@ -159,20 +159,27 @@ export const POST: APIRoute = async ({ request }) => {
 		let buffer = '';
 		let insideThink = false;
 		/**
-		 * Look-behind buffer: holds the last TAG_WINDOW chars of clean output
-		 * so that a tag split across SSE tokens (e.g. "<thi" | "nk>") is caught
-		 * before any fragment leaks to the client.
+		 * Look-behind buffer: holds the last TAG_WINDOW chars across tokens
+		 * so that either tag (<think> or </think>) split across SSE frames
+		 * is caught before any fragment leaks or gets dropped.
+		 * Reused by both branches — only one is active at a time.
 		 */
-		const TAG_WINDOW = 7; // length of '<think>' (longest open tag)
+		const TAG_WINDOW = 8; // length of '</think>' (longest tag)
 		let tagCarry = '';
 
-		/** Flush any held-back carry text to the client as a normal token. */
+		/**
+		 * Flush any held-back carry text to the client as a normal token.
+		 * Only emits when outside a think block — if insideThink is true,
+		 * the carry holds think-block tail bytes that must be discarded.
+		 */
 		const flushCarry = async () => {
 			if (!tagCarry) return;
-			fullResponse += tagCarry;
-			await writer.write(encoder.encode(
-				`data: ${JSON.stringify({ response: tagCarry })}\n\n`
-			));
+			if (!insideThink) {
+				fullResponse += tagCarry;
+				await writer.write(encoder.encode(
+					`data: ${JSON.stringify({ response: tagCarry })}\n\n`
+				));
+			}
 			tagCarry = '';
 		};
 
@@ -183,6 +190,8 @@ export const POST: APIRoute = async ({ request }) => {
 		 * Tags split across tokens are handled by prepending `tagCarry`
 		 * to each new token, running the state machine on the combined
 		 * string, then holding back the trailing TAG_WINDOW chars.
+		 * This applies to both the open-tag (clean text) and close-tag
+		 * (inside-think) branches.
 		 */
 		const processSseLine = async (line: string) => {
 			const trimmed = line.trim();
@@ -225,7 +234,12 @@ export const POST: APIRoute = async ({ request }) => {
 								`data: ${JSON.stringify({ response: '', thinking: false })}\n\n`
 							));
 						} else {
-							token = ''; // drop — still inside think block
+							// Retain trailing TAG_WINDOW chars in case </think>
+							// straddles this token and the next one.
+							tagCarry = token.length > TAG_WINDOW
+								? token.slice(-TAG_WINDOW)
+								: token;
+							token = ''; // drop the rest — still inside think block
 						}
 					}
 				}

--- a/src/pages/api/agent.ts
+++ b/src/pages/api/agent.ts
@@ -220,7 +220,14 @@ export const POST: APIRoute = async ({ request }) => {
 					if (!insideThink) {
 						const idx = token.indexOf('<think>');
 						if (idx !== -1) {
-							clean += token.slice(0, idx);
+							const preThink = clean + token.slice(0, idx);
+							if (preThink) {
+								fullResponse += preThink;
+								await writer.write(encoder.encode(
+									`data: ${JSON.stringify({ response: preThink })}\n\n`
+								));
+							}
+							clean = '';
 							insideThink = true;
 							token = token.slice(idx + 7);
 							await writer.write(encoder.encode(
@@ -293,6 +300,16 @@ export const POST: APIRoute = async ({ request }) => {
 			if (buffer) await processSseLine(buffer);
 			// Flush any remaining look-behind carry to the client
 			await flushCleanCarry();
+
+			if (insideThink) {
+				try {
+					await writer.write(encoder.encode(
+						`data: ${JSON.stringify({ response: '', thinking: false })}\n\n`
+					));
+				} catch (err) {
+					console.error('[agent] failed to write terminal thinking:false frame:', err);
+				}
+			}
 
 			reader.releaseLock();
 			// Close the writer immediately so the client sees the stream end

--- a/src/pages/api/agent.ts
+++ b/src/pages/api/agent.ts
@@ -158,15 +158,37 @@ export const POST: APIRoute = async ({ request }) => {
 		const reader = aiStream.getReader();
 		let buffer = '';
 		let insideThink = false;
+		/**
+		 * Look-behind buffer: holds the last TAG_WINDOW chars of clean output
+		 * so that a tag split across SSE tokens (e.g. "<thi" | "nk>") is caught
+		 * before any fragment leaks to the client.
+		 */
+		const TAG_WINDOW = 7; // length of '<think>' (longest open tag)
+		let tagCarry = '';
+
+		/** Flush any held-back carry text to the client as a normal token. */
+		const flushCarry = async () => {
+			if (!tagCarry) return;
+			fullResponse += tagCarry;
+			await writer.write(encoder.encode(
+				`data: ${JSON.stringify({ response: tagCarry })}\n\n`
+			));
+			tagCarry = '';
+		};
 
 		/**
 		 * Process one SSE line: strip <think>…</think> blocks,
 		 * emit `thinking` signals, and forward only clean tokens.
+		 *
+		 * Tags split across tokens are handled by prepending `tagCarry`
+		 * to each new token, running the state machine on the combined
+		 * string, then holding back the trailing TAG_WINDOW chars.
 		 */
 		const processSseLine = async (line: string) => {
 			const trimmed = line.trim();
 			if (!trimmed.startsWith('data: ')) return;
 			if (trimmed.includes('[DONE]')) {
+				await flushCarry();
 				await writer.write(encoder.encode(line + '\n'));
 				return;
 			}
@@ -174,10 +196,12 @@ export const POST: APIRoute = async ({ request }) => {
 				const data = JSON.parse(trimmed.slice(6)) as { response?: string };
 				if (!data.response) return;
 
-				let token = data.response;
+				// Prepend any held-back carry so split tags are visible
+				let token = tagCarry + data.response;
+				tagCarry = '';
 				let clean = '';
 
-				// Simple state machine for <think>…</think> boundaries
+				// State machine for <think>…</think> boundaries
 				while (token.length > 0) {
 					if (!insideThink) {
 						const idx = token.indexOf('<think>');
@@ -207,10 +231,18 @@ export const POST: APIRoute = async ({ request }) => {
 				}
 
 				if (clean) {
-					fullResponse += clean;
-					await writer.write(encoder.encode(
-						`data: ${JSON.stringify({ response: clean })}\n\n`
-					));
+					// Hold back the trailing TAG_WINDOW chars in case a tag
+					// straddles this token and the next one.
+					if (clean.length > TAG_WINDOW) {
+						const emit = clean.slice(0, -TAG_WINDOW);
+						tagCarry = clean.slice(-TAG_WINDOW);
+						fullResponse += emit;
+						await writer.write(encoder.encode(
+							`data: ${JSON.stringify({ response: emit })}\n\n`
+						));
+					} else {
+						tagCarry = clean;
+					}
 				}
 			} catch {
 				// Ignore malformed or incomplete SSE lines
@@ -235,6 +267,8 @@ export const POST: APIRoute = async ({ request }) => {
 			// Flush any remaining bytes held by the decoder
 			buffer += decoder.decode();
 			if (buffer) await processSseLine(buffer);
+			// Flush any remaining look-behind carry to the client
+			await flushCarry();
 
 			reader.releaseLock();
 			// Close the writer immediately so the client sees the stream end

--- a/src/pages/api/agent.ts
+++ b/src/pages/api/agent.ts
@@ -121,7 +121,7 @@ export const POST: APIRoute = async ({ request }) => {
 	} catch (err) {
 		console.error(`[agent:${reqId}] context build failed:`, err);
 		systemPrompt =
-			"You are Sybil Melton's digital twin. Answer questions about her professional background honestly and helpfully.";
+			"You ARE Sybil Melton — her digital twin. Always speak in the first person (I, me, my). Never use third-person pronouns about yourself. Answer questions about your professional background, creative projects, and interests honestly and helpfully.";
 	}
 
 	const messages = [
@@ -151,20 +151,69 @@ export const POST: APIRoute = async ({ request }) => {
 	const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>();
 	const writer = writable.getWriter();
 	const decoder = new TextDecoder();
+	const encoder = new TextEncoder();
 	let fullResponse = '';
 
 	(async () => {
 		const reader = aiStream.getReader();
 		let buffer = '';
+		let insideThink = false;
 
-		const appendResponseFromSseLine = (line: string) => {
-			const trimmedLine = line.trim();
-			if (!trimmedLine.startsWith('data: ') || trimmedLine.includes('[DONE]')) return;
+		/**
+		 * Process one SSE line: strip <think>…</think> blocks,
+		 * emit `thinking` signals, and forward only clean tokens.
+		 */
+		const processSseLine = async (line: string) => {
+			const trimmed = line.trim();
+			if (!trimmed.startsWith('data: ')) return;
+			if (trimmed.includes('[DONE]')) {
+				await writer.write(encoder.encode(line + '\n'));
+				return;
+			}
 			try {
-				const data = JSON.parse(trimmedLine.slice(6)) as { response?: string };
-				if (data.response) fullResponse += data.response;
+				const data = JSON.parse(trimmed.slice(6)) as { response?: string };
+				if (!data.response) return;
+
+				let token = data.response;
+				let clean = '';
+
+				// Simple state machine for <think>…</think> boundaries
+				while (token.length > 0) {
+					if (!insideThink) {
+						const idx = token.indexOf('<think>');
+						if (idx !== -1) {
+							clean += token.slice(0, idx);
+							insideThink = true;
+							token = token.slice(idx + 7);
+							await writer.write(encoder.encode(
+								`data: ${JSON.stringify({ response: '', thinking: true })}\n\n`
+							));
+						} else {
+							clean += token;
+							token = '';
+						}
+					} else {
+						const idx = token.indexOf('</think>');
+						if (idx !== -1) {
+							insideThink = false;
+							token = token.slice(idx + 8);
+							await writer.write(encoder.encode(
+								`data: ${JSON.stringify({ response: '', thinking: false })}\n\n`
+							));
+						} else {
+							token = ''; // drop — still inside think block
+						}
+					}
+				}
+
+				if (clean) {
+					fullResponse += clean;
+					await writer.write(encoder.encode(
+						`data: ${JSON.stringify({ response: clean })}\n\n`
+					));
+				}
 			} catch {
-				// Ignore malformed or incomplete SSE lines until they can be completed
+				// Ignore malformed or incomplete SSE lines
 			}
 		};
 
@@ -172,15 +221,12 @@ export const POST: APIRoute = async ({ request }) => {
 			while (true) {
 				const { done, value } = await reader.read();
 				if (done) break;
-				await writer.write(value);
-				// Collect tokens from SSE lines to form the complete response
 				buffer += decoder.decode(value, { stream: true });
 				const lines = buffer.split('\n');
-				// Keep the last element in the buffer — it may be an incomplete line
-				// that will be completed by the next chunk.
+				// Keep the last element — it may be an incomplete line
 				buffer = lines.pop() ?? '';
 				for (const line of lines) {
-					appendResponseFromSseLine(line);
+					await processSseLine(line);
 				}
 			}
 		} catch (err) {
@@ -188,12 +234,15 @@ export const POST: APIRoute = async ({ request }) => {
 		} finally {
 			// Flush any remaining bytes held by the decoder
 			buffer += decoder.decode();
-			if (buffer) appendResponseFromSseLine(buffer);
+			if (buffer) await processSseLine(buffer);
 
 			reader.releaseLock();
 			// Close the writer immediately so the client sees the stream end
 			// before the (slower) DO persistence call below.
 			writer.close();
+
+			// Safety-net regex to catch edge cases (e.g. tags split across tokens)
+			fullResponse = fullResponse.replace(/<think>[\s\S]*?<\/think>/g, '').trimStart();
 
 			// ── 6. Persist both turns to the DO after stream completes ─────
 			if (fullResponse) {


### PR DESCRIPTION
This pull request introduces improvements to both the system prompt and the chat streaming logic, focusing on enforcing strict first-person identity for the digital twin and adding a "thinking" status for the AI agent. The changes ensure more accurate persona emulation and provide better user feedback during response generation.

**Persona enforcement and prompt improvements:**

* The system prompt in `buildSystemPrompt` and the fallback prompt in the API handler are rewritten to strictly require first-person pronouns, never allowing third-person references to Sybil. Explicit rules, examples, and correction instructions are added to prevent identity drift. [[1]](diffhunk://#diff-bf6894e8b0c7b174d596609afda3a299eb31c9496e933158299fd863788660f3L24-R33) [[2]](diffhunk://#diff-c46ed597e27775e4a0639be6d05e0f62402bbee42fbc596467ec45ccf7da2bbfL124-R124)

**Streaming and "thinking" state handling:**

* The API streaming logic in `src/pages/api/agent.ts` is refactored to detect `<think>…</think>` blocks in model output, emitting special SSE signals (`thinking: true/false`) to the client and stripping these blocks from the user-visible response. This includes a state machine for tag boundaries and a safety-net regex to clean up any leaked fragments.
* The `AgentChat` React component and its `Message` type are updated to support and display a "thinking" state. When the agent is "thinking," a distinct visual indicator is shown instead of the standard streaming cursor. [[1]](diffhunk://#diff-63d57c3995d958ef1012376920529f7215ad62b053f2e5019df51b6190079699R11) [[2]](diffhunk://#diff-63d57c3995d958ef1012376920529f7215ad62b053f2e5019df51b6190079699L99-R108) [[3]](diffhunk://#diff-63d57c3995d958ef1012376920529f7215ad62b053f2e5019df51b6190079699L117-R134) [[4]](diffhunk://#diff-63d57c3995d958ef1012376920529f7215ad62b053f2e5019df51b6190079699R210-R219)