### PR TITLE
Add middleware for Cloudflare Workers compatibility in Astro 6

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -47,6 +47,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Manual Trivy Setup
+        uses: aquasecurity/setup-trivy@v0.2.0
+        with:
+          cache: true
+          version: v0.71.0
+
       - name: Trivy scan (PR — vuln + secret)
         if: github.event_name == 'pull_request'
         uses: aquasecurity/trivy-action@v0.36.0
@@ -57,6 +63,7 @@ jobs:
           exit-code: 1
           format: sarif
           output: trivy-results.sarif
+          skip-setup-trivy: true
 
       - name: Trivy scan (push to main — vuln + secret + misconfig)
         if: github.event_name == 'push'
@@ -68,6 +75,7 @@ jobs:
           exit-code: 1
           format: sarif
           output: trivy-results.sarif
+          skip-setup-trivy: true
 
       - name: Upload Trivy SARIF to GitHub Security tab
         if: success() || failure()

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Manual Trivy Setup
-        uses: aquasecurity/setup-trivy@v0.2.0
+        uses: aquasecurity/setup-trivy@v0.3.1
         with:
           cache: true
           version: v0.71.0

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,31 @@
+import { defineMiddleware } from 'astro:middleware';
+
+/**
+ * Compatibility shim for packages that still access Astro.locals.runtime.env,
+ * which was removed in Astro v6 (see https://docs.astro.build/en/guides/upgrade-to/v6/).
+ *
+ * @keystatic/astro reads context.locals.runtime.env to discover the Cloudflare
+ * secrets (KEYSTATIC_GITHUB_CLIENT_ID, etc.) at request time. In Astro v6 the
+ * adapter no longer populates that namespace; instead secrets are available via
+ * `import { env } from "cloudflare:workers"`.
+ *
+ * This middleware lazily injects a `runtime.env` object so that Keystatic's
+ * handler can resolve its secrets without modification. On local dev (Node.js
+ * adapter) the dynamic import of "cloudflare:workers" will throw and the shim
+ * is silently skipped, which is correct — local Keystatic uses `kind: "local"`
+ * storage and never reaches the GitHub OAuth path.
+ */
+export const onRequest = defineMiddleware(async (context, next) => {
+	// Only inject the shim when we're running inside Cloudflare Workers and the
+	// runtime object isn't already present (guards against double-injection).
+	if (typeof (context.locals as any).runtime === 'undefined') {
+		try {
+			const { env } = await import('cloudflare:workers');
+			(context.locals as any).runtime = { env };
+		} catch {
+			// Not in Cloudflare runtime — local dev, no-op.
+		}
+	}
+
+	return next();
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,10 +18,11 @@ import { defineMiddleware } from 'astro:middleware';
 export const onRequest = defineMiddleware(async (context, next) => {
 	// Only inject the shim when we're running inside Cloudflare Workers and the
 	// runtime object isn't already present (guards against double-injection).
-	if (typeof (context.locals as any).runtime === 'undefined') {
+	const localsAny = context.locals as any;
+	if (!localsAny.runtime?.env) {
 		try {
-			const { env } = await import('cloudflare:workers');
-			(context.locals as any).runtime = { env };
+			const { env } = await import(/* @vite-ignore */ 'cloudflare:workers');
+			localsAny.runtime = { ...(localsAny.runtime ?? {}), env };
 		} catch {
 			// Not in Cloudflare runtime — local dev, no-op.
 		}


### PR DESCRIPTION
This pull request introduces a compatibility middleware to address breaking changes in Astro v6 related to environment variable access for packages such as `@keystatic/astro`. The middleware ensures that legacy code expecting `Astro.locals.runtime.env` continues to function, particularly for Cloudflare deployments.

**Compatibility shim for environment variables:**

* Added `src/middleware.ts` with middleware that injects a `runtime.env` object into `context.locals` when running on Cloudflare Workers, allowing packages like `@keystatic/astro` to access secrets as before Astro v6. The shim is skipped in local development where it is unnecessary.